### PR TITLE
Feat/delete reaction

### DIFF
--- a/src/lib/constants/reactions.ts
+++ b/src/lib/constants/reactions.ts
@@ -1,0 +1,11 @@
+import type { ReactionEmoji } from "$lib/types/chat";
+
+export const DEFAULT_REACTION_EMOJIS: ReactionEmoji[] = [
+    { emoji: "❤️", name: "heart" },
+    { emoji: "👍", name: "thumbs_up" },
+    { emoji: "👎", name: "thumbs_down" },
+    { emoji: "😂", name: "laugh" },
+    { emoji: "🤔", name: "thinking" },
+    { emoji: "🤙", name: "call_me" },
+    { emoji: "😥", name: "sad" },
+];

--- a/src/lib/constants/reactions.ts
+++ b/src/lib/constants/reactions.ts
@@ -6,6 +6,6 @@ export const DEFAULT_REACTION_EMOJIS: ReactionEmoji[] = [
     { emoji: "👎", name: "thumbs_down" },
     { emoji: "😂", name: "laugh" },
     { emoji: "🤔", name: "thinking" },
-    { emoji: "🤙", name: "call_me" },
+    { emoji: "🤙", name: "pura_vida" },
     { emoji: "😥", name: "sad" },
 ];

--- a/src/lib/stores/chat.test.ts
+++ b/src/lib/stores/chat.test.ts
@@ -641,8 +641,6 @@ describe('Chat Store', () => {
         group: createTestGroup(),
         relays: ['test-relay']
       };
-
-      console.log('HERE INVOICE MESSAGE INSIDE TEST IS', invoiceMessage);
       
       const result = await chatStore.payLightningInvoice(groupWithRelays, invoiceMessage);
       

--- a/src/lib/stores/chat.test.ts
+++ b/src/lib/stores/chat.test.ts
@@ -341,7 +341,7 @@ describe('Chat Store', () => {
       expect(get(chatStore).messages).toHaveLength(0);
     });
 
-    it('clears reactions', () => {
+    it('clears messages reactions', () => {
       const messageEvent = createMessageEvent('msg-1', 'Hello world', 1000);
       chatStore.handleEvent(messageEvent);
       const reactionEvent = createReactionEvent('reaction-1', '👍', 1500, 'msg-1');
@@ -352,6 +352,18 @@ describe('Chat Store', () => {
       chatStore.handleEvent(messageEvent);
       const newMessage = chatStore.findMessage('msg-1');
       expect(newMessage?.reactions).toEqual([]);
+    });
+
+    it('clears reactions', () => {
+      const messageEvent = createMessageEvent('msg-1', 'Hello world', 1000);
+      chatStore.handleEvent(messageEvent);
+      const reactionEvent = createReactionEvent('reaction-1', '👍', 1500, 'msg-1');
+      chatStore.handleEvent(reactionEvent);
+      const oldMessage = chatStore.findMessage('msg-1');
+      expect(oldMessage?.reactions).toHaveLength(1);
+      chatStore.clear();
+      chatStore.handleEvent(messageEvent);
+      expect(chatStore.findReaction('reaction-1')).toBeUndefined();
     });
 
     it('clears deletions', () => {
@@ -392,6 +404,31 @@ describe('Chat Store', () => {
       const message = chatStore.findMessage('non-existent');
       
       expect(message).toBeUndefined();
+    });
+  });
+
+  describe('findReaction', () => {
+    it('finds a reaction by id', () => {
+      const messageEvent = createMessageEvent('msg-1', 'Hello world', 1000);
+      chatStore.handleEvent(messageEvent);
+      const reactionEvent = createReactionEvent('reaction-1', '👋', 1001, 'msg-1');
+      chatStore.handleEvent(reactionEvent);
+      const reaction = chatStore.findReaction('reaction-1');
+      expect(reaction).toEqual({
+        id: 'reaction-1',
+        pubkey: 'other-pubkey',
+        content: '👋',
+        targetId: 'msg-1',
+        createdAt: 1001,
+        isMine: false,
+        event: reactionEvent
+      });
+    });
+
+    it('returns undefined for a non-existent reaction', () => {
+      const reaction = chatStore.findReaction('non-existent');
+      
+      expect(reaction).toBeUndefined();
     });
   });
 

--- a/src/lib/stores/chat.ts
+++ b/src/lib/stores/chat.ts
@@ -38,6 +38,7 @@ export function createChatStore() {
         handleEvents,
         clear,
         findMessage,
+        findReaction,
         findReplyToMessage,
         isDeleted,
         getMessageReactionsSummary,
@@ -151,6 +152,7 @@ export function createChatStore() {
     function clear() {
         messagesMap.set(new Map());
         deletionsMap.set(new Map());
+        reactionsMap.set(new Map());
     }
 
     /**
@@ -161,6 +163,15 @@ export function createChatStore() {
     function findMessage(id: string): Message | undefined {
         const messages = get(messagesMap); 
         return messages.get(id);
+    }
+    /**
+     * Finds a reaction by its ID
+     * @param {string} id - The ID of the reaction to find
+     * @returns {Reaction | undefined} The found reaction or undefined
+     */
+    function findReaction(id: string): Reaction | undefined {
+        const reactions = get(reactionsMap);
+        return reactions.get(id);
     }
 
     /**
@@ -368,6 +379,7 @@ export function createChatStore() {
         handleEvents,
         clear,
         findMessage,
+        findReaction,
         findReplyToMessage,
         isDeleted,
         getMessageReactionsSummary,

--- a/src/lib/stores/chat.ts
+++ b/src/lib/stores/chat.ts
@@ -236,7 +236,6 @@ export function createChatStore() {
         message: Message
     ): Promise<NEvent | null> {
         if (!message.lightningInvoice) {
-            console.log('HERE MESSAGE IS', message);
             console.error("Message does not have a lightning invoice");
             return null;
         }

--- a/src/lib/types/chat.ts
+++ b/src/lib/types/chat.ts
@@ -1,7 +1,21 @@
 import type { NEvent, NostrMlsGroup, NostrMlsGroupWithRelays } from './nostr';
 
+/**
+ * Represents a chat message in the application
+ * @property {string} id - Unique identifier for the message
+ * @property {string} pubkey - Public key of the message sender
+ * @property {string} content - Text content of the message
+ * @property {number} createdAt - Unix timestamp when the message was created
+ * @property {string} [replyToId] - ID of the message this is replying to, if applicable
+ * @property {Reaction[]} reactions - Array of reactions to this message
+ * @property {LightningInvoice} [lightningInvoice] - Lightning invoice details if message contains one
+ * @property {LightningPayment} [lightningPayment] - Lightning payment details if message is a payment
+ * @property {boolean} isSingleEmoji - Whether the message consists of only a single emoji
+ * @property {boolean} isMine - Whether the current user is the author of this message
+ * @property {NEvent} event - The original Nostr event data
+ */
 export type Message = {
-    id: string;
+    id: string; 
     pubkey: string;
     content: string;
     createdAt: number;
@@ -14,6 +28,16 @@ export type Message = {
     event: NEvent;
 }
 
+/**
+ * Represents a reaction to a message
+ * @property {string} id - Unique identifier for the reaction
+ * @property {string} pubkey - Public key of the user who reacted
+ * @property {string} content - The reaction content (typically an emoji)
+ * @property {number} createdAt - Unix timestamp when the reaction was created
+ * @property {string} targetId - ID of the message this reaction targets
+ * @property {boolean} isMine - Whether the current user is the author of this reaction
+ * @property {NEvent} event - The original Nostr event data
+ */
 export type Reaction = {
     id: string;
     pubkey: string;
@@ -24,11 +48,23 @@ export type Reaction = {
     event: NEvent;
 }
 
+/**
+ * Summary of reactions to a message, grouping by emoji
+ * @property {string} emoji - The emoji used in the reaction
+ * @property {number} count - Number of users who reacted with this emoji
+ */
 export type ReactionSummary = {
     emoji: string;
     count: number;
 }
 
+/**
+ * Represents a Lightning Network invoice in a message
+ * @property {string} invoice - The Lightning invoice string (BOLT11 format)
+ * @property {number} amount - The amount in satoshis
+ * @property {string} [description] - Optional description of what the invoice is for
+ * @property {boolean} isPaid - Whether the invoice has been paid
+ */
 export type LightningInvoice = {
     invoice: string;
     amount: number;
@@ -36,11 +72,23 @@ export type LightningInvoice = {
     isPaid: boolean;
 };
 
+/**
+ * Represents a Lightning Network payment
+ * @property {string} preimage - Payment preimage (proof of payment)
+ * @property {boolean} isPaid - Whether the payment was successful
+ */
 export type LightningPayment = {
     preimage: string;
     isPaid: boolean;
 }
 
+/**
+ * Represents a message deletion event
+ * @property {string} id - Unique identifier for the deletion event
+ * @property {string} pubkey - Public key of the user who deleted the message
+ * @property {string} targetId - ID of the message that was deleted
+ * @property {NEvent} event - The original Nostr event data
+ */
 export type Deletion = {
     id: string;
     pubkey: string;
@@ -48,12 +96,38 @@ export type Deletion = {
     event: NEvent;
 }
 
+/**
+ * Map of message IDs to Message objects for efficient lookup
+ */
 export type MessagesMap = Map<string, Message>;
 
+/**
+ * Map of reaction IDs to Reaction objects for efficient lookup
+ */
 export type ReactionsMap = Map<string, Reaction>;
 
+/**
+ * Map of deletion target IDs to Deletion objects for efficient lookup
+ */
 export type DeletionsMap = Map<string, Deletion>;
 
+/**
+ * State and methods for managing a chat conversation
+ * @property {Message[]} messages - Array of messages in the chat, sorted by creation time
+ * @property {function} handleEvent - Processes a single Nostr event and updates state
+ * @property {function} handleEvents - Processes multiple Nostr events and updates state
+ * @property {function} clear - Clears all messages and state
+ * @property {function} findMessage - Finds a message by its ID
+ * @property {function} findReplyToMessage - Finds the message that another message is replying to
+ * @property {function} isDeleted - Checks if a message has been deleted
+ * @property {function} getMessageReactionsSummary - Gets a summary of reactions for a message
+ * @property {function} hasReactions - Checks if a message has any reactions
+ * @property {function} clickReaction - Toggles a reaction on a message
+ * @property {function} deleteMessage - Deletes a message
+ * @property {function} payLightningInvoice - Pays a Lightning invoice in a message
+ * @property {function} isMessageDeletable - Checks if a message can be deleted
+ * @property {function} isMessageCopyable - Checks if a message content can be copied
+ */
 export type ChatState = {
     messages: Message[];
     handleEvent: (event: NEvent) => void;

--- a/src/lib/types/chat.ts
+++ b/src/lib/types/chat.ts
@@ -128,6 +128,7 @@ export type DeletionsMap = Map<string, Deletion>;
  * @property {function} handleEvents - Processes multiple Nostr events and updates state
  * @property {function} clear - Clears all messages and state
  * @property {function} findMessage - Finds a message by its ID
+ * @property {function} findReaction - Finds a reaction by its ID
  * @property {function} findReplyToMessage - Finds the message that another message is replying to
  * @property {function} isDeleted - Checks if a message has been deleted
  * @property {function} getMessageReactionsSummary - Gets a summary of reactions for a message
@@ -144,6 +145,7 @@ export type ChatState = {
     handleEvents: (events: NEvent[]) => void;
     clear: () => void;
     findMessage: (id: string) => Message | undefined;
+    findReaction: (id: string) => Reaction | undefined;
     findReplyToMessage: (message: Message) => Message | undefined;
     isDeleted: (eventId: string) => boolean;
     getMessageReactionsSummary: (messageId: string) => ReactionSummary[];

--- a/src/lib/types/chat.ts
+++ b/src/lib/types/chat.ts
@@ -1,4 +1,4 @@
-import type { NEvent } from './nostr';
+import type { NEvent, NostrMlsGroup, NostrMlsGroupWithRelays } from './nostr';
 
 export type Message = {
     id: string;
@@ -64,9 +64,9 @@ export type ChatState = {
     isDeleted: (eventId: string) => boolean;
     getMessageReactionsSummary: (messageId: string) => ReactionSummary[];
     hasReactions: (message: Message) => boolean;
-    sendReaction: (group: any, reaction: string, messageId: string) => Promise<NEvent | null>;
-    deleteMessage: (group: any, messageId: string) => Promise<NEvent | null>;
-    payLightningInvoice: (groupWithRelays: any, message: Message) => Promise<NEvent | null>;
+    clickReaction: (group: NostrMlsGroup, reaction: string, messageId: string) => Promise<NEvent | null>;
+    deleteMessage: (group: NostrMlsGroup, messageId: string) => Promise<NEvent | null>;
+    payLightningInvoice: (groupWithRelays: NostrMlsGroupWithRelays, message: Message) => Promise<NEvent | null>;
     isMessageDeletable: (messageId: string) => boolean;
     isMessageCopyable: (messageId: string) => boolean;
 };

--- a/src/lib/types/chat.ts
+++ b/src/lib/types/chat.ts
@@ -20,6 +20,7 @@ export type Reaction = {
     content: string;
     createdAt: number;
     targetId: string;
+    isMine: boolean;
     event: NEvent;
 }
 

--- a/src/lib/types/chat.ts
+++ b/src/lib/types/chat.ts
@@ -59,6 +59,16 @@ export type ReactionSummary = {
 }
 
 /**
+ * Represents an emoji reaction in a message
+ * @property {string} emoji - The emoji used in the reaction
+ * @property {string} [name] - Optional name for the reaction
+ */
+export type ReactionEmoji = {
+    emoji: string;
+    name?: string;
+}
+
+/**
  * Represents a Lightning Network invoice in a message
  * @property {string} invoice - The Lightning invoice string (BOLT11 format)
  * @property {number} amount - The amount in satoshis

--- a/src/lib/utils/__tests__/reaction.test.ts
+++ b/src/lib/utils/__tests__/reaction.test.ts
@@ -20,14 +20,30 @@ describe("eventToReaction", () => {
     };
     
     it('returns a Reaction object', () => {
-      const result = eventToReaction(event);
+      const result = eventToReaction(event, "test-pubkey");
       expect(result).toEqual({
         id: "test-id",
         pubkey: "test-pubkey",
         content: "👍",
         createdAt: 1234567890,
         targetId: "target-event-id",
+        isMine: true,
         event
+      });
+    });
+
+    describe('with a different pubkey', () => {
+      it('isMine of reaction is false', () => {
+        const result = eventToReaction(event, "other-pubkey");
+        expect(result).toEqual({
+          id: "test-id",
+          pubkey: "test-pubkey",
+          content: "👍",
+          createdAt: 1234567890,
+          targetId: "target-event-id",
+          isMine: false,
+          event
+        });
       });
     });
   });
@@ -47,7 +63,7 @@ describe("eventToReaction", () => {
     };
 
     it('returns null', () => {
-      expect(eventToReaction(event)).toBeNull();
+      expect(eventToReaction(event, "test-pubkey")).toBeNull();
     });
   });
 
@@ -67,7 +83,7 @@ describe("eventToReaction", () => {
     };
 
     it('returns null', () => {
-      expect(eventToReaction(event)).toBeNull();
+      expect(eventToReaction(event, "test-pubkey")).toBeNull();
     });
   });
 });

--- a/src/lib/utils/deletion.ts
+++ b/src/lib/utils/deletion.ts
@@ -2,6 +2,12 @@ import type { NEvent } from "$lib/types/nostr";
 import type { Deletion } from '$lib/types/chat';
 import { findTargetId } from './tags';
 
+/**
+ * Converts a Nostr event to a Deletion object.
+ * 
+ * @param event - The Nostr event to convert
+ * @returns A Deletion object or null if the event doesn't have a valid target ID
+ */
 export function eventToDeletion(event: NEvent): Deletion | null {
     const targetId = findTargetId(event);
     if (!targetId) return null;

--- a/src/lib/utils/message.ts
+++ b/src/lib/utils/message.ts
@@ -3,6 +3,12 @@ import type { Message } from '$lib/types/chat';
 import { findReplyToId } from './tags';
 import { eventToLightningInvoice, eventToLightningPayment } from './lightning';
 
+/**
+ * Determines if a string contains only a single emoji.
+ * 
+ * @param str - The string to check
+ * @returns True if the string contains only a single emoji, false otherwise
+ */
 function isSingleEmoji(str: string) {
     const trimmed = str.trim();
     const emojiRegex =
@@ -10,6 +16,15 @@ function isSingleEmoji(str: string) {
     return emojiRegex.test(trimmed);
 }
 
+/**
+ * Formats message content to hide full lightning invoices for display purposes.
+ * If an invoice is present, it replaces the full invoice with a shortened version
+ * showing only the first and last 15 characters.
+ * 
+ * @param content - The message content
+ * @param invoice - The lightning invoice string, if present
+ * @returns Formatted content with shortened invoice (if applicable)
+ */
 function contentToShow(
     { content, invoice }:
     { content: string, invoice: string | undefined }
@@ -20,6 +35,15 @@ function contentToShow(
     return content.replace(invoice, `${firstPart}...${lastPart}`);
 }
 
+/**
+ * Converts a Nostr event to a Message object.
+ * Processes the event to extract relevant information and format it appropriately,
+ * including handling lightning invoices/payments and emoji detection.
+ * 
+ * @param event - The Nostr event to convert
+ * @param currentPubkey - The current user's public key, used to determine if the message belongs to the current user
+ * @returns A formatted Message object
+ */
 export function eventToMessage(event: NEvent, currentPubkey: string | undefined): Message {
     const replyToId = findReplyToId(event);
     const isMine = currentPubkey === event.pubkey;

--- a/src/lib/utils/reaction.ts
+++ b/src/lib/utils/reaction.ts
@@ -2,6 +2,13 @@ import type { NEvent } from "$lib/types/nostr";
 import type { Reaction } from '$lib/types/chat';
 import { findTargetId } from './tags';
 
+/**
+ * Converts a Nostr event to a Reaction object.
+ * 
+ * @param event - The Nostr event to convert
+ * @param currentPubkey - The current user's public key, used to determine if the reaction belongs to the current user
+ * @returns A Reaction object or null if the event doesn't have a valid target ID
+ */
 export function eventToReaction(event: NEvent, currentPubkey: string | undefined): Reaction | null {
     const targetId = findTargetId(event);
     if (!targetId) return null;

--- a/src/lib/utils/reaction.ts
+++ b/src/lib/utils/reaction.ts
@@ -2,9 +2,10 @@ import type { NEvent } from "$lib/types/nostr";
 import type { Reaction } from '$lib/types/chat';
 import { findTargetId } from './tags';
 
-export function eventToReaction(event: NEvent): Reaction | null {
+export function eventToReaction(event: NEvent, currentPubkey: string | undefined): Reaction | null {
     const targetId = findTargetId(event);
     if (!targetId) return null;
+    const isMine = currentPubkey === event.pubkey;
 
     return {
         id: event.id,
@@ -12,6 +13,7 @@ export function eventToReaction(event: NEvent): Reaction | null {
         content: event.content,
         createdAt: event.created_at,
         targetId,
+        isMine,
         event
     };
 }

--- a/src/lib/utils/tags.ts
+++ b/src/lib/utils/tags.ts
@@ -1,17 +1,45 @@
 import type { NEvent } from "$lib/types/nostr";
 
+/**
+ * Finds the target event ID in a Nostr event's tags.
+ * Looks for the first "e" tag
+ * 
+ * @param event - The Nostr event to search for target ID
+ * @returns The target event ID if found, undefined otherwise
+ */
 export function findTargetId(event: NEvent): string | undefined{
     return event.tags.find((t) => t[0] === "e")?.[1];
 } 
 
+/**
+ * Finds the bolt11 Lightning invoice tag in a Nostr event.
+ * Used for identifying Lightning Network payment info.
+ * 
+ * @param event - The Nostr event to search for bolt11 tag
+ * @returns The bolt11 tag array if found, undefined otherwise
+ */
 export function findBolt11Tag(event: NEvent): string[] | undefined {
     return event.tags.find((t) => t[0] === "bolt11");
 }
 
+/**
+ * Finds the payment preimage in a Nostr event's tags.
+ * The preimage is used as proof of payment in Lightning Network transactions.
+ * 
+ * @param event - The Nostr event to search for preimage
+ * @returns The preimage string if found, undefined otherwise
+ */
 export function findPreimage(event: NEvent): string | undefined {
   return event.tags.find((t) => t[0] === "preimage")?.[1];
 }
 
+/**
+ * Finds the reply-to event ID in a Nostr event's tags.
+ * Looks for the first "q" tag
+ * 
+ * @param event - The Nostr event to search for reply-to ID
+ * @returns The ID of the event being replied to if found, undefined otherwise
+ */
 export function findReplyToId(event: NEvent): string | undefined {
   return event.tags.find((t) => t[0] === "q")?.[1];
 }

--- a/src/routes/(app)/chats/[id]/+page.svelte
+++ b/src/routes/(app)/chats/[id]/+page.svelte
@@ -224,7 +224,7 @@ function handleOutsideClick() {
     selectedMessageId = undefined;
 }
 
-async function sendReaction(reaction: string, messageId: string | null | undefined) {
+async function clickReaction(reaction: string, messageId: string | null | undefined) {
     if (!group) {
         console.error("no group found");
         return;
@@ -233,7 +233,10 @@ async function sendReaction(reaction: string, messageId: string | null | undefin
         console.error("no message selected");
         return;
     }
-    chatStore.sendReaction(group, reaction, messageId)
+    chatStore.clickReaction(group, reaction, messageId)
+        .catch((err) => {
+            console.error("Failed to apply reaction:", err);
+        })
         .finally(() => {
             showMessageMenu = false;
         });
@@ -493,7 +496,7 @@ onDestroy(() => {
                             </div>
                             <div class="reactions flex flex-row gap-2 absolute -bottom-6 right-0">
                                 {#each chatStore.getMessageReactionsSummary(message.id) as {emoji, count}}
-                                    <button onclick={() => sendReaction(emoji, message.id)} class="py-1 px-2 bg-gray-900 rounded-full flex flex-row gap-1 items-center">
+                                    <button onclick={() => clickReaction(emoji, message.id)} class="py-1 px-2 bg-gray-900 rounded-full flex flex-row gap-1 items-center">
                                         {emoji}
                                         {#if count > 1}
                                             <span class="text-sm opacity-60">{count}</span>
@@ -526,13 +529,13 @@ onDestroy(() => {
     role="menu"
 >
     <div class="flex flex-row gap-3 text-xl">
-        <button onclick={() => sendReaction("❤️", selectedMessageId)} class="p-3">❤️</button>
-        <button onclick={() => sendReaction("👍", selectedMessageId)} class="p-3">👍</button>
-        <button onclick={() => sendReaction("👎", selectedMessageId)} class="p-3">👎</button>
-        <button onclick={() => sendReaction("😂", selectedMessageId)} class="p-3">😂</button>
-        <button onclick={() => sendReaction("🤔", selectedMessageId)} class="p-3">🤔</button>
-        <button onclick={() => sendReaction("🤙", selectedMessageId)} class="p-3">🤙</button>
-        <button onclick={() => sendReaction("😥", selectedMessageId)} class="p-3">😥</button>
+        <button onclick={() => clickReaction("❤️", selectedMessageId)} class="p-3">❤️</button>
+        <button onclick={() => clickReaction("👍", selectedMessageId)} class="p-3">👍</button>
+        <button onclick={() => clickReaction("👎", selectedMessageId)} class="p-3">👎</button>
+        <button onclick={() => clickReaction("😂", selectedMessageId)} class="p-3">😂</button>
+        <button onclick={() => clickReaction("🤔", selectedMessageId)} class="p-3">🤔</button>
+        <button onclick={() => clickReaction("🤙", selectedMessageId)} class="p-3">🤙</button>
+        <button onclick={() => clickReaction("😥", selectedMessageId)} class="p-3">😥</button>
     </div>
 </div>
 

--- a/src/routes/(app)/chats/[id]/+page.svelte
+++ b/src/routes/(app)/chats/[id]/+page.svelte
@@ -38,7 +38,7 @@ import {
 import { onDestroy, onMount, tick } from "svelte";
 import { type PressCustomEvent, press } from "svelte-gestures";
 import type { Message } from "$lib/types/chat";
-
+import { DEFAULT_REACTION_EMOJIS } from "$lib/constants/reactions";
 let unlistenMlsMessageReceived: UnlistenFn;
 let unlistenMlsMessageProcessed: UnlistenFn;
 
@@ -529,13 +529,11 @@ onDestroy(() => {
     role="menu"
 >
     <div class="flex flex-row gap-3 text-xl">
-        <button onclick={() => clickReaction("❤️", selectedMessageId)} class="p-3">❤️</button>
-        <button onclick={() => clickReaction("👍", selectedMessageId)} class="p-3">👍</button>
-        <button onclick={() => clickReaction("👎", selectedMessageId)} class="p-3">👎</button>
-        <button onclick={() => clickReaction("😂", selectedMessageId)} class="p-3">😂</button>
-        <button onclick={() => clickReaction("🤔", selectedMessageId)} class="p-3">🤔</button>
-        <button onclick={() => clickReaction("🤙", selectedMessageId)} class="p-3">🤙</button>
-        <button onclick={() => clickReaction("😥", selectedMessageId)} class="p-3">😥</button>
+        {#each DEFAULT_REACTION_EMOJIS as reaction (reaction.name)}
+            <button onclick={() => clickReaction(reaction.emoji, selectedMessageId)} class="p-3" title={reaction.name}>
+                {reaction.emoji}
+            </button>
+        {/each}
     </div>
 </div>
 


### PR DESCRIPTION
# Context
When a user had already reacted to a message and tapped it again, the number of reactions increased. We want to handle that case  by deleting the existing reaction instead of adding one, as explained in this issue: https://github.com/parres-hq/whitenoise/issues/70

A video of the issue:

https://github.com/user-attachments/assets/301c90c8-ffa4-44b2-bd8d-606e2e953b4a


# What has been done
The method to send a reaction was modified to support deletions when the user has already reacted with the same content.

Also autogenerated docstrings where added  to the chat store and relateds utils files after coderabbit suggested to explain what isMine property was. I have doubts if it is useful to add them or not really.. 🤔  What do you think?

**Commit by commit:**
- Removes some logs that I left by error while debugging in last PR
- Adds isMine property to reactions.  Messages that already had that property.
- Modifies the method of the chat store that sends a reaction to delete a reaction when the user has one with the same content
- Adds docstrings to chat store , chat types and other related utils files 
- Moves default reactions buttons to array to follow code rabbit suggestion
- Fixes chat store clear method, thanks to coderabbit that noticed that reactions weren't fully cleared. To make it easier, to test added a findReaction method to the chat store.

Now it works this way:

https://github.com/user-attachments/assets/2e3f459a-e556-467c-b7e7-188027e69edf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Enhanced message reaction interactions now allow users to toggle their reactions seamlessly. User reactions display accurate ownership, making it clear which reactions are yours.
  - New utility functions added for handling Nostr event tags, improving the functionality related to Lightning Network payments and event replies.
  - Introduced new properties in messages, including support for replies and reactions, enhancing message context.
  - Added support for predefined reaction emojis, improving user experience in selecting reactions.

- **Refactor**
  - Streamlined the underlying reaction processing to ensure consistent handling across various scenarios, resulting in a smoother and more reliable chat experience.
  - Updated naming conventions for reaction-related functions to improve clarity and consistency throughout the codebase.

- **Documentation**
  - Enhanced documentation for new and existing functions, providing clarity on their purposes and parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->