### PR TITLE
Add rustfmt & clippy project settings files

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,9 @@
+[target.'cfg(all())']
+rustflags = [
+    "-W", "warnings",           # Show warnings but don't treat them as errors
+    "-W", "clippy::nursery",    # Enable new lints that are still being tested
+    "-W", "clippy::style",      # Style-related lints
+    "-W", "clippy::correctness", # Correctness-related lints
+    "-W", "clippy::complexity",  # Complexity-related lints
+    "-W", "clippy::perf",       # Performance-related lints
+]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,7 +1,6 @@
 [target.'cfg(all())']
 rustflags = [
     "-W", "warnings",           # Show warnings but don't treat them as errors
-    "-W", "clippy::nursery",    # Enable new lints that are still being tested
     "-W", "clippy::style",      # Style-related lints
     "-W", "clippy::correctness", # Correctness-related lints
     "-W", "clippy::complexity",  # Complexity-related lints

--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,0 +1,4 @@
+# Clippy configuration
+cognitive-complexity-threshold = 30
+too-many-arguments-threshold = 8
+# Add other clippy configurations as needed

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,3 +104,6 @@ jobs:
 
       - name: Run clippy
         run: cd src-tauri && cargo clippy ${{ matrix.args }} -- -D warnings
+
+      - name: Check formatting
+        run: cd src-tauri && cargo fmt -- --check

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ White Noise aims to be the most secure private chat app on Nostr, with a focus o
 
 ## The Spec
 
-White Noise is an implemenetation of the [NIP-104](https://github.com/nostr-protocol/nips/pull/1427) spec. This is still a draft spec, so it may change before it is finalized.
+White Noise is an implementation of the [NIP-104](https://github.com/nostr-protocol/nips/pull/1427) spec. This is still a draft spec, so it may change before it is finalized.
 
 ## Running White Noise
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A secure, private, and decentralized chat app built on Nostr, using the MLS prot
 White Noise aims to be the most secure private chat app on Nostr, with a focus on privacy and security. Under the hood, it uses the [Messaging Layer Security](https://www.rfc-editor.org/rfc/rfc9420.html) (MLS) protocol to manage group communications in a highly secure way. Nostr is used as the transport protocol and as the framework for the ongoing conversation in each chat.
 
 ## Status
+
 ![CI](https://github.com/erskingardner/whitenoise/actions/workflows/ci.yml/badge.svg?event=push)
 
 ![Linux Build](https://github.com/erskingardner/whitenoise/actions/workflows/build_linux.yml/badge.svg?event=push) ![Android Build](https://github.com/erskingardner/whitenoise/actions/workflows/build_android.yml/badge.svg?event=push)
@@ -31,10 +32,12 @@ To build the app in release mode for desktop, run `bun tauri build`.
 ### Linux
 
 - To provide a stable and reproducible build environment for Linux, the provided Dockerfile can be used:
+
 ```
 docker build -t tauri-app -f Dockerfile.linux_build .
 docker run --rm -v $(pwd):/app tauri-app
 ```
+
 The resulting build artifacts (`.deb`, `.rpm` and `.AppImage` packages) will be created in the `src-tauri/target/release/bundle` directory.
 
 ### Windows
@@ -57,6 +60,22 @@ White Noise is built with [Tauri](https://tauri.app/) & [SvelteKit](https://kit.
 2. Clone the repo: `git clone https://github.com/erskingardner/whitenoise.git` and `cd whitenoise`.
 3. Run `bun install` to install the front-end dependencies.
 4. Run `bun tauri dev` to start the app. If you want to see more comprehensive logging, run `RUST_LOG=debug bun tauri dev`.
+
+### Formatting and Linting
+
+Before submitting code, please run both Clippy and Rustfmt to check for issues:
+
+Clippy (linting):
+
+```sh
+cd src-tauri && cargo clippy --no-deps
+```
+
+Rustfmt
+
+```sh
+cd src-tauri && cargo fmt
+```
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ To build the app in release mode for desktop, run `bun tauri build`.
 
 - To provide a stable and reproducible build environment for Linux, the provided Dockerfile can be used:
 
-```
+```sh
 docker build -t tauri-app -f Dockerfile.linux_build .
 docker run --rm -v $(pwd):/app tauri-app
 ```

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,6 @@
+[toolchain]
+channel = "stable"
+components = [
+    "rustfmt",
+    "clippy",
+]

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -3,3 +3,4 @@ edition = "2021"  # Specify your Rust edition
 max_width = 100   # Maximum line width
 tab_spaces = 4    # Number of spaces per tab
 newline_style = "Unix"  # Line ending style
+reorder_modules = true  # Reorder module declarations

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,5 @@
+# Default settings for rustfmt
+edition = "2021"  # Specify your Rust edition
+max_width = 100   # Maximum line width
+tab_spaces = 4    # Number of spaces per tab
+newline_style = "Unix"  # Line ending style

--- a/src-tauri/src/commands/groups/create_group.rs
+++ b/src-tauri/src/commands/groups/create_group.rs
@@ -114,8 +114,7 @@ pub async fn create_group(
         let member_pubkey = PublicKey::from_hex(&member.pubkey).map_err(|e| e.to_string())?;
         let contact =
             fetch_enriched_contact(member.pubkey.clone(), false, wn.clone(), app_handle.clone())
-                .await
-                .map_err(|e| e.to_string())?;
+                .await?;
 
         // We only want to connect to user relays in release mode
         let relay_urls: Vec<String> = if cfg!(dev) {
@@ -282,7 +281,7 @@ pub async fn create_group(
         .await
         .map_err(|e| format!("Failed to get groups: {}", e))?
         .into_iter()
-        .map(|group| group.nostr_group_id.clone())
+        .map(|group| group.nostr_group_id)
         .collect::<Vec<_>>();
 
     wn.nostr

--- a/src-tauri/src/commands/invites/accept_invite.rs
+++ b/src-tauri/src/commands/invites/accept_invite.rs
@@ -69,7 +69,7 @@ pub async fn accept_invite(
         .await
         .map_err(|e| format!("Failed to get groups: {}", e))?
         .into_iter()
-        .map(|group| group.nostr_group_id.clone())
+        .map(|group| group.nostr_group_id)
         .collect::<Vec<_>>();
 
     wn.nostr

--- a/src-tauri/src/commands/payments/pay_invoice.rs
+++ b/src-tauri/src/commands/payments/pay_invoice.rs
@@ -20,7 +20,7 @@ pub enum CommandError {
 
 impl From<PaymentError> for CommandError {
     fn from(err: PaymentError) -> Self {
-        CommandError::PaymentError(err.to_string())
+        Self::PaymentError(err.to_string())
     }
 }
 
@@ -94,7 +94,7 @@ async fn pay_invoice_and_get_msg_params(
     Ok(MlsMessageParams {
         message: "".to_string(),
         kind: 9,
-        tags: Some(create_payment_tags(tags, &preimage.to_string())),
+        tags: Some(create_payment_tags(tags, &preimage)),
     })
 }
 

--- a/src-tauri/src/messages.rs
+++ b/src-tauri/src/messages.rs
@@ -55,8 +55,8 @@ pub enum ProcessedMessageState {
 impl From<String> for ProcessedMessageState {
     fn from(s: String) -> Self {
         match s.to_lowercase().as_str() {
-            "processed" => ProcessedMessageState::Processed,
-            "failed" => ProcessedMessageState::Failed,
+            "processed" => Self::Processed,
+            "failed" => Self::Failed,
             _ => panic!("Invalid processed message state: {}", s),
         }
     }
@@ -94,7 +94,7 @@ pub struct ProcessedMessage {
 
 impl From<ProcessedMessageRow> for ProcessedMessage {
     fn from(row: ProcessedMessageRow) -> Self {
-        ProcessedMessage {
+        Self {
             event_id: EventId::parse(&row.event_id).unwrap(),
             message_event_id: row.message_event_id.map(|id| EventId::parse(&id).unwrap()),
             account_pubkey: PublicKey::from_hex(&row.account_pubkey).unwrap(),
@@ -123,7 +123,7 @@ impl ProcessedMessage {
     pub async fn find_by_event_id(
         event_id: EventId,
         wn: tauri::State<'_, Whitenoise>,
-    ) -> Result<Option<ProcessedMessage>> {
+    ) -> Result<Option<Self>> {
         let active_account = Account::get_active(wn.clone()).await?;
 
         let processed_message_row = sqlx::query_as::<_, ProcessedMessageRow>(
@@ -164,7 +164,7 @@ impl ProcessedMessage {
         state: ProcessedMessageState,
         reason: String,
         wn: tauri::State<'_, Whitenoise>,
-    ) -> Result<ProcessedMessage> {
+    ) -> Result<Self> {
         let active_account = Account::get_active(wn.clone()).await?;
 
         let mut txn = wn.database.pool.begin().await?;
@@ -180,7 +180,7 @@ impl ProcessedMessage {
             .await?;
         txn.commit().await?;
 
-        Ok(ProcessedMessage {
+        Ok(Self {
             event_id,
             message_event_id,
             account_pubkey: active_account.pubkey,
@@ -195,7 +195,7 @@ impl Message {
     pub async fn find_by_event_id(
         event_id: EventId,
         wn: tauri::State<'_, Whitenoise>,
-    ) -> Result<Message> {
+    ) -> Result<Self> {
         let active_account = Account::get_active(wn.clone()).await?;
 
         let message_row = sqlx::query_as::<_, MessageRow>(
@@ -215,7 +215,7 @@ impl Message {
 
 impl From<MessageRow> for Message {
     fn from(row: MessageRow) -> Self {
-        Message {
+        Self {
             event_id: EventId::parse(&row.event_id).unwrap(),
             account_pubkey: PublicKey::from_hex(&row.account_pubkey).unwrap(),
             author_pubkey: PublicKey::from_hex(&row.author_pubkey).unwrap(),

--- a/src-tauri/src/nostr_manager/event_processor.rs
+++ b/src-tauri/src/nostr_manager/event_processor.rs
@@ -69,7 +69,7 @@ impl EventProcessor {
     pub fn new(app_handle: AppHandle) -> Self {
         let (sender, receiver) = mpsc::channel(500);
         let (shutdown_tx, shutdown_rx) = mpsc::channel(1);
-        let app_handle_clone = app_handle.clone();
+        let app_handle_clone = app_handle;
 
         // Spawn the processing loop
         tokio::spawn(async move {

--- a/src-tauri/src/relays.rs
+++ b/src-tauri/src/relays.rs
@@ -18,7 +18,7 @@ pub struct Relay {
     pub group_id: Option<Vec<u8>>,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Copy)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Copy)]
 pub enum RelayType {
     Nostr,
     Inbox,
@@ -29,10 +29,10 @@ pub enum RelayType {
 impl From<String> for RelayType {
     fn from(s: String) -> Self {
         match s.to_lowercase().as_str() {
-            "nostr" => RelayType::Nostr,
-            "inbox" => RelayType::Inbox,
-            "key_package" => RelayType::KeyPackage,
-            "group" => RelayType::Group,
+            "nostr" => Self::Nostr,
+            "inbox" => Self::Inbox,
+            "key_package" => Self::KeyPackage,
+            "group" => Self::Group,
             _ => panic!("Invalid relay type: {}", s),
         }
     }

--- a/src-tauri/src/secrets_store.rs
+++ b/src-tauri/src/secrets_store.rs
@@ -351,7 +351,11 @@ pub fn get_export_secret_keys_for_group(
 /// # Returns
 ///
 /// * `Result<()>` - Ok(()) if successful, or an error if the operation fails
-pub fn store_nostr_wallet_connect_uri(pubkey: &str, nostr_wallet_connect_uri: &str, data_dir: &Path) -> Result<()> {
+pub fn store_nostr_wallet_connect_uri(
+    pubkey: &str,
+    nostr_wallet_connect_uri: &str,
+    data_dir: &Path,
+) -> Result<()> {
     let mut secrets = read_secrets_file(data_dir).unwrap_or(json!({}));
     let key = format!("nwc:{}", pubkey);
     let obfuscated_uri = obfuscate(nostr_wallet_connect_uri, data_dir);
@@ -373,7 +377,7 @@ pub fn store_nostr_wallet_connect_uri(pubkey: &str, nostr_wallet_connect_uri: &s
 pub fn get_nostr_wallet_connect_uri(pubkey: &str, data_dir: &Path) -> Result<Option<String>> {
     let secrets = read_secrets_file(data_dir)?;
     let key = format!("nwc:{}", pubkey);
-    
+
     match secrets[key].as_str() {
         Some(obfuscated_uri) => Ok(Some(deobfuscate(obfuscated_uri, data_dir)?)),
         None => Ok(None),
@@ -562,7 +566,8 @@ mod tests {
         store_nostr_wallet_connect_uri(pubkey, nostr_wallet_connect_uri, temp_dir.path())?;
 
         // Retrieve the NWC URI
-        let retrieved_uri = get_nostr_wallet_connect_uri(pubkey, temp_dir.path())?.expect("URI should exist");
+        let retrieved_uri =
+            get_nostr_wallet_connect_uri(pubkey, temp_dir.path())?.expect("URI should exist");
         assert_eq!(nostr_wallet_connect_uri, retrieved_uri);
 
         // Clean up


### PR DESCRIPTION
I've tried to add some basic settings files to help ensure consistency. 

To run clippy linting: 

```sh
cd src-tauri && cargo clippy --no-deps
```

To run rustfmt:

```sh
cd src-tauri && cargo fmt
```

I've fixed quite a few clippy warnings but there are a good number that still remain and we should address them sooner or later. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Added standardized configurations for the toolchain, code formatting, and quality checks.
  - Introduced a new CI job step for checking code formatting.

- **Refactor**
  - Streamlined processing for accounts, groups, invites, messages, and events.
  - Optimized error handling and data processing for a more efficient experience.
  - Enhanced code readability by utilizing `Self` in method signatures and enum implementations.

- **Style**
  - Improved code readability and consistency to support long-term maintainability.
  - Reformatted function signatures and added spacing for clarity in various files.

- **Documentation**
  - Updated the README to include guidelines for formatting and linting practices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->