### PR TITLE
Feat/replies improvements

### DIFF
--- a/src/lib/components/ChatsList.svelte
+++ b/src/lib/components/ChatsList.svelte
@@ -248,9 +248,9 @@ $effect(() => {
                         <Sheet.Title>{$t("chats.search")}</Sheet.Title>
                     </Sheet.Header>
                     <div class="flex flex-col gap-2 px-6">
-                        <Input type="search"  placeholder={$t("chats.searchPlaceholder")+"&hellip;"} class="focus-visible:ring-0" />
+                        <Input type="search"  placeholder={$t("chats.searchPlaceholder")} class="focus-visible:ring-0" />
                     </div>
-                    <div class="flex flex-col gap-2 px-6 mt-6 text-destructive">Not implemented yet</div>
+                    <div class="flex flex-col gap-2 px-6 mt-6 text-destructive">{$t("shared.notImplementedYet")}</div>
                 </Sheet.Content>
             </Sheet.Root>
 
@@ -334,7 +334,7 @@ $effect(() => {
                                         {/if}
                                         <div class="mt-4">
                                             {#if isSearching}
-                                                <h2 class="text-xl font-normal mb-2 px-6">{$t("chats.searching")} &hellip;</h2>
+                                                <h2 class="text-xl font-normal mb-2 px-6">{$t("chats.searching")}</h2>
                                                 <div class="px-6">
                                                     <Loader size={40} fullscreen={false} />
                                                 </div>

--- a/src/lib/components/MessageBar.stories.svelte
+++ b/src/lib/components/MessageBar.stories.svelte
@@ -1,6 +1,6 @@
 <script lang="ts" module>
+import type { Message } from "$lib/types/chat";
 import { NostrMlsGroupType } from "$lib/types/nostr";
-import type { NEvent } from "$lib/types/nostr";
 import { defineMeta } from "@storybook/addon-svelte-csf";
 import MessageBar from "./MessageBar.svelte";
 
@@ -54,6 +54,7 @@ const mockReplyMessage = {
     reactions: [],
     isSingleEmoji: false,
     isMine: false,
+    tokens: [{ Text: "This is a test message being replied to" }],
     event: {
         id: "test_event_id",
         pubkey: "test_pubkey",
@@ -64,7 +65,7 @@ const mockReplyMessage = {
     },
 };
 
-function handleNewMessage(message: NEvent) {
+function handleNewMessage(message: Message) {
     console.log("New message:", message);
 }
 </script>

--- a/src/lib/components/MessageBar.svelte
+++ b/src/lib/components/MessageBar.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+import MessageTokens from "$lib/components/MessageTokens.svelte";
 import { activeAccount } from "$lib/stores/accounts";
 import type { ChatMessage, Message } from "$lib/types/chat";
 import type { NostrMlsGroup, NostrMlsGroupWithRelays } from "$lib/types/nostr";
@@ -205,7 +206,8 @@ onMount(() => {
                     <TrashCan size={20} /><span class="italic opacity-60">{$t("chats.messageDeleted")}</span>
                 </div>
             {:else}
-                <span>{replyToMessage.content}</span>
+               <MessageTokens tokens={replyToMessage.tokens} reply={true} />
+
             {/if}
             <button onclick={() => replyToMessage = undefined} class="p-1 bg-primary hover:bg-primary/80 rounded-full mr-0">
                 <CloseLarge size={16} class="text-primary-foreground" />

--- a/src/lib/components/MessageBar.svelte
+++ b/src/lib/components/MessageBar.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 import { activeAccount } from "$lib/stores/accounts";
-import type { CachedMessage, Message } from "$lib/types/chat";
+import type { ChatMessage, Message } from "$lib/types/chat";
 import type { NostrMlsGroup, NostrMlsGroupWithRelays } from "$lib/types/nostr";
 import { hexMlsGroupId } from "$lib/utils/group";
 import { invoke } from "@tauri-apps/api/core";
@@ -15,8 +15,6 @@ import { onMount } from "svelte";
 import { _ as t } from "svelte-i18n";
 import { toast } from "svelte-sonner";
 import Loader from "./Loader.svelte";
-import Button from "./ui/button/button.svelte";
-import Textarea from "./ui/textarea/textarea.svelte";
 let {
     group,
     replyToMessage = $bindable(),
@@ -24,8 +22,8 @@ let {
     isReplyToMessageDeleted = $bindable(false),
 }: {
     group: NostrMlsGroup;
-    replyToMessage?: Message;
-    handleNewMessage: (message: CachedMessage) => void;
+    replyToMessage?: ChatMessage;
+    handleNewMessage: (message: Message) => void;
     isReplyToMessageDeleted?: boolean;
 } = $props();
 
@@ -75,7 +73,7 @@ async function sendMessage() {
         tags,
     };
 
-    handleNewMessage(tmpMessage as unknown as CachedMessage);
+    handleNewMessage(tmpMessage as unknown as Message);
     sendingMessage = true;
 
     await invoke("send_mls_message", {
@@ -96,8 +94,8 @@ async function sendMessage() {
                 })
         ),
     })
-        .then((cachedMessage) => {
-            handleNewMessage(cachedMessage as CachedMessage);
+        .then((tmpMessage: Message) => {
+            handleNewMessage(tmpMessage);
             message = "";
             media = []; // Clear media after successful send
             setTimeout(adjustTextareaHeight, 0);

--- a/src/lib/components/MessageBar.svelte
+++ b/src/lib/components/MessageBar.svelte
@@ -53,7 +53,7 @@ async function sendMessage() {
 
     // Check if any uploads are still in progress
     if (media.some((item) => item.status === "uploading")) {
-        toast.info("Please wait for uploads to complete");
+        toast.info($t("chats.waitMediaUpload"));
         return;
     }
 

--- a/src/lib/components/MessageTokens.svelte
+++ b/src/lib/components/MessageTokens.svelte
@@ -2,6 +2,10 @@
 import type { SerializableToken } from "$lib/types/nostr";
 
 export let tokens: SerializableToken[];
+/**
+ * When true, renders in reply mode: limits display to 2 lines with ellipsis and renders URLs as plain text
+ */
+export let reply = false;
 
 function getTokenType(token: SerializableToken | string): string {
     if (typeof token === "string") {
@@ -19,12 +23,16 @@ function getTokenValue(token: SerializableToken | string): string | null {
 }
 </script>
 
-<div class="message-tokens">
+<div class="message-tokens" class:reply>
     {#each tokens as token}
         {#if 'Text' in token}
             <span class="text">{token.Text}</span>
         {:else if 'Url' in token}
+          { #if reply}
+            <span class="text">{token.Url}</span>
+          {:else}
             <a href={token.Url} target="_blank" rel="noopener noreferrer" class="url">{token.Url}</a>
+          {/if}
         {:else if 'Hashtag' in token}
             <span class="hashtag">#{token.Hashtag}</span>
         {:else if 'Nostr' in token}
@@ -42,6 +50,14 @@ function getTokenValue(token: SerializableToken | string): string | null {
         display: inline;
         white-space: pre-wrap;
         word-break: break-word;
+    }
+
+    .message-tokens.reply {
+        display: -webkit-box;
+        -webkit-line-clamp: 2;
+        -webkit-box-orient: vertical;
+        overflow: hidden;
+        text-overflow: ellipsis;
     }
 
     .url {

--- a/src/lib/components/RepliedTo.svelte
+++ b/src/lib/components/RepliedTo.svelte
@@ -3,8 +3,8 @@ import { activeAccount } from "$lib/stores/accounts";
 import { type ChatMessage } from "$lib/types/chat";
 import TrashCan from "carbon-icons-svelte/lib/TrashCan.svelte";
 import { _ as t } from "svelte-i18n";
+import MessageTokens from "./MessageTokens.svelte";
 import Name from "./Name.svelte";
-
 let {
     message,
     isDeleted = $bindable(false),
@@ -12,10 +12,22 @@ let {
     message: ChatMessage | undefined;
     isDeleted?: boolean;
 } = $props();
+
+function scrollToMessage() {
+    if (!message) return;
+    const messageNode = document.getElementById(message?.id);
+    if (messageNode) {
+        messageNode.scrollIntoView({ behavior: "smooth", block: "center" });
+    }
+}
 </script>
 
 {#if message}
-    <div class="flex flex-col gap-1 bg-primary-foreground text-primary rounded-sm p-2 border-l-4 border-l-white dark:border-l-black pl-4 mb-2 text-sm">
+    <button 
+        class="flex flex-col gap-1 bg-primary-foreground text-primary rounded-sm p-2 border-l-4 border-l-white dark:border-l-black pl-4 mb-2 text-sm"
+        onclick={scrollToMessage}
+        aria-label={$t("chats.scrollToMessage")}
+    >
             {#if message.pubkey === $activeAccount?.pubkey}
                 <span class="font-medium">{$t("chats.you")}</span>
             {:else}
@@ -28,9 +40,9 @@ let {
                 <TrashCan size={20} /><span class="italic opacity-60">{$t("chats.messageDeleted")}</span>
             </div>
         {:else}
-            <span class="break-words-smart">{message.content}</span>
+            <MessageTokens tokens={message.tokens} reply={true} />
         {/if}
-    </div>
+    </button>
 {:else}
     <div class="flex flex-col gap-1 bg-primary-foreground text-primary rounded-sm p-2 border-l-4 border-l-white dark:border-l-black pl-4 mb-2 text-sm">
         <span class="font-medium">

--- a/src/lib/components/RepliedTo.svelte
+++ b/src/lib/components/RepliedTo.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 import { activeAccount } from "$lib/stores/accounts";
-import { type Message } from "$lib/types/chat";
+import { type ChatMessage } from "$lib/types/chat";
 import TrashCan from "carbon-icons-svelte/lib/TrashCan.svelte";
 import { _ as t } from "svelte-i18n";
 import Name from "./Name.svelte";
@@ -9,7 +9,7 @@ let {
     message,
     isDeleted = $bindable(false),
 }: {
-    message: Message | undefined;
+    message: ChatMessage | undefined;
     isDeleted?: boolean;
 } = $props();
 </script>

--- a/src/lib/locales/de.json
+++ b/src/lib/locales/de.json
@@ -1,7 +1,8 @@
 {
     "shared": {
         "cancel": "Abbrechen",
-        "loading": "Laden..."
+        "loading": "Laden...",
+        "notImplementedYet": "Noch nicht implementiert"
     },
     "settings": {
         "title": "Einstellungen",
@@ -116,9 +117,9 @@
         "unknownError": "Unbekannter Fehler",
         "contacts": "Kontakte",
         "noContactsFound": "Keine Kontakte gefunden",
-        "searching": "Suche läuft",
+        "searching": "Suche läuft...",
         "searchResults": "Suchergebnisse",
-        "searchPlaceholder": "Kontakte oder Chats suchen",
+        "searchPlaceholder": "Kontakte oder Chats suchen...",
         "noChatSelected": "Hast du heute das Gras berührt?",
         "startSecureChat": "Sicheren Chat starten",
         "contactNotSetUp": "ist noch nicht für sichere Nachrichten eingerichtet",
@@ -151,7 +152,8 @@
         "acceptInvite": "Einladung annehmen",
         "acceptingInvite": "Einladung wird angenommen...",
         "inviteAccepted": "Du hast eine Einladung zu einem sicheren Chat mit {name} angenommen",
-        "inviteDeclined": "Du hast eine Einladung zu einem sicheren Chat mit {name} abgelehnt"
+        "inviteDeclined": "Du hast eine Einladung zu einem sicheren Chat mit {name} abgelehnt",
+        "waitMediaUpload": "Bitte warten Sie auf den Abschluss des Uploads"
     },
     "login": {
         "signInWithNostrKey": "Mit Nostr-Schlüssel anmelden",

--- a/src/lib/locales/en.json
+++ b/src/lib/locales/en.json
@@ -1,7 +1,8 @@
 {
     "shared": {
         "cancel": "Cancel",
-        "loading": "Loading..."
+        "loading": "Loading...",
+        "notImplementedYet": "Not implemented yet"
     },
     "settings": {
         "title": "Settings",
@@ -116,9 +117,9 @@
         "unknownError": "Unknown error",
         "contacts": "Contacts",
         "noContactsFound": "No contacts found",
-        "searching": "Searching",
+        "searching": "Searching...",
         "searchResults": "Search results",
-        "searchPlaceholder": "Search contacts or chats",
+        "searchPlaceholder": "Search contacts or chats...",
         "noChatSelected": "Have you touched grass today?",
         "startSecureChat": "Start secure chat",
         "contactNotSetUp": "is not yet set up to use secure messaging",
@@ -151,7 +152,8 @@
         "acceptInvite": "Accept invite",
         "acceptingInvite": "Accepting invite...",
         "inviteAccepted": "You've accepted an invite to join a secure chat with {name}",
-        "inviteDeclined": "You've declined an invite to join a secure chat with {name}"
+        "inviteDeclined": "You've declined an invite to join a secure chat with {name}",
+        "waitMediaUpload": "Please wait for uploads to complete"
     },
     "login": {
         "signInWithNostrKey": "Sign in with Nostr key",

--- a/src/lib/locales/es.json
+++ b/src/lib/locales/es.json
@@ -1,7 +1,8 @@
 {
     "shared": {
         "cancel": "Cancelar",
-        "loading": "Cargando..."
+        "loading": "Cargando...",
+        "notImplementedYet": "Estamos trabajando en ello"
     },
     "settings": {
         "title": "Configuración",
@@ -116,9 +117,9 @@
         "unknownError": "Error desconocido",
         "contacts": "Contactos",
         "noContactsFound": "No se encontraron contactos",
-        "searching": "Buscando",
+        "searching": "Buscando...",
         "searchResults": "Resultados de la búsqueda",
-        "searchPlaceholder": "Buscar contactos o conversaciones",
+        "searchPlaceholder": "Buscar contactos o conversaciones...",
         "noChatSelected": "¿Has salido a tomar aire hoy?",
         "startSecureChat": "Iniciar conversación segura",
         "contactNotSetUp": "no puede usar mensajería segura",
@@ -151,14 +152,15 @@
         "acceptInvite": "Aceptar invitación",
         "acceptingInvite": "Aceptando invitación...",
         "inviteAccepted": "Has aceptado una invitación para unirte a un chat seguro con {name}",
-        "inviteDeclined": "Has rechazado una invitación para unirte a un chat seguro con {name}"
+        "inviteDeclined": "Has rechazado una invitación para unirte a un chat seguro con {name}",
+        "waitMediaUpload": "Por favor, espera a que terminen de subir los archivos"
     },
     "login": {
         "signInWithNostrKey": "Iniciar sesión con tu llave de Nostr",
         "createNewNostrKey": "Crear una nueva llave de Nostr",
         "signInDescription": "Tu llave será cifrada y almacenada únicamente en tu dispositivo.",
         "logIn": "Iniciar sesión",
-        "welcomeTo": "Bienvenido a {appName}",
+        "welcomeTo": "Bienvenido a",
         "slogan": "Seguro. Distribuido. Incensurable."
     },
     "clipboard": {

--- a/src/lib/locales/it.json
+++ b/src/lib/locales/it.json
@@ -1,7 +1,8 @@
 {
     "shared": {
         "cancel": "Annulla",
-        "loading": "Caricamento..."
+        "loading": "Caricamento...",
+        "notImplementedYet": "Non ancora implementato"
     },
     "settings": {
         "title": "Impostazioni",
@@ -116,9 +117,9 @@
         "unknownError": "Errore sconosciuto",
         "contacts": "Contatti",
         "noContactsFound": "Nessun contatto trovato",
-        "searching": "Ricerca in corso",
+        "searching": "Ricerca in corso...",
         "searchResults": "Risultati ricerca",
-        "searchPlaceholder": "Cerca contatti o chat",
+        "searchPlaceholder": "Cerca contatti o chat...",
         "noChatSelected": "Hai toccato l'erba oggi?",
         "startSecureChat": "Inizia chat sicura",
         "contactNotSetUp": "non è ancora configurato per utilizzare la messaggistica sicura",
@@ -151,7 +152,8 @@
         "acceptInvite": "Accetta invito",
         "acceptingInvite": "Accettazione invito in corso...",
         "inviteAccepted": "Hai accettato un invito a partecipare a una chat sicura con {name}",
-        "inviteDeclined": "Hai rifiutato un invito a partecipare a una chat sicura con {name}"
+        "inviteDeclined": "Hai rifiutato un invito a partecipare a una chat sicura con {name}",
+        "waitMediaUpload": "Attendere il completamento del caricamento"
     },
     "login": {
         "signInWithNostrKey": "Accedi con chiave Nostr",

--- a/src/lib/types/chat.ts
+++ b/src/lib/types/chat.ts
@@ -19,7 +19,7 @@ import type {
  * @property {SerializableToken[]} tokens - The tokenized message content
  * @property {string} outer_event_id - The ID of the outer event, if applicable
  */
-export type CachedMessage = {
+export type Message = {
     event_id: string;
     account_pubkey: string;
     author_pubkey: string;
@@ -39,7 +39,7 @@ export type CachedMessage = {
  * @property {string} content - Text content of the message
  * @property {number} createdAt - Unix timestamp when the message was created
  * @property {string} [replyToId] - ID of the message this is replying to, if applicable
- * @property {Reaction[]} reactions - Array of reactions to this message
+ * @property {ReactionMessage[]} reactions - Array of reactions to this message
  * @property {LightningInvoice} [lightningInvoice] - Lightning invoice details if message contains one
  * @property {LightningPayment} [lightningPayment] - Lightning payment details if message is a payment
  * @property {boolean} isSingleEmoji - Whether the message consists of only a single emoji
@@ -47,13 +47,13 @@ export type CachedMessage = {
  * @property {NEvent} event - The original Nostr event data
  * @property {SerializableToken[]} tokens - The tokenized message content
  */
-export type Message = {
+export type ChatMessage = {
     id: string;
     pubkey: string;
     content: string;
     createdAt: number;
     replyToId?: string;
-    reactions: Reaction[];
+    reactions: ReactionMessage[];
     lightningInvoice?: LightningInvoice;
     lightningPayment?: LightningPayment;
     isSingleEmoji: boolean;
@@ -72,7 +72,7 @@ export type Message = {
  * @property {boolean} isMine - Whether the current user is the author of this reaction
  * @property {NEvent} event - The original Nostr event data
  */
-export type Reaction = {
+export type ReactionMessage = {
     id: string;
     pubkey: string;
     content: string;
@@ -127,13 +127,13 @@ export type LightningPayment = {
 };
 
 /**
- * Represents a message deletion event
+ * Represents the deletion of a message
  * @property {string} id - Unique identifier for the deletion event
  * @property {string} pubkey - Public key of the user who deleted the message
  * @property {string} targetId - ID of the message that was deleted
  * @property {NEvent} event - The original Nostr event data
  */
-export type Deletion = {
+export type DeletionMessage = {
     id: string;
     pubkey: string;
     targetId: string;
@@ -141,29 +141,29 @@ export type Deletion = {
 };
 
 /**
- * Map of message IDs to Message objects for efficient lookup
+ * Map of message IDs to ChatMessage objects for efficient lookup
  */
-export type MessagesMap = Map<string, Message>;
+export type ChatMessagesMap = Map<string, ChatMessage>;
 
 /**
- * Map of reaction IDs to Reaction objects for efficient lookup
+ * Map of reaction IDs to ReactionMessage objects for efficient lookup
  */
-export type ReactionsMap = Map<string, Reaction>;
+export type ReactionMessagesMap = Map<string, ReactionMessage>;
 
 /**
- * Map of deletion target IDs to Deletion objects for efficient lookup
+ * Map of deletion target IDs to DeletionMessage objects for efficient lookup
  */
-export type DeletionsMap = Map<string, Deletion>;
+export type DeletionMessagesMap = Map<string, DeletionMessage>;
 
 /**
  * State and methods for managing a chat conversation
- * @property {Message[]} messages - Array of messages in the chat, sorted by creation time
+ * @property {ChatMessage[]} messages - Array of messages in the chat, sorted by creation time
  * @property {function} handleEvent - Processes a single Nostr event and updates state
  * @property {function} handleEvents - Processes multiple Nostr events and updates state
  * @property {function} clear - Clears all messages and state
- * @property {function} findMessage - Finds a message by its ID
- * @property {function} findReaction - Finds a reaction by its ID
- * @property {function} findReplyToMessage - Finds the message that another message is replying to
+ * @property {function} findChatMessage - Finds a chat message by its ID
+ * @property {function} findReactionMessage - Finds a reaction message by its ID
+ * @property {function} findReplyToChatMessage - Finds the message that another message is replying to
  * @property {function} isDeleted - Checks if a message has been deleted
  * @property {function} getMessageReactionsSummary - Gets a summary of reactions for a message
  * @property {function} hasReactions - Checks if a message has any reactions
@@ -174,26 +174,26 @@ export type DeletionsMap = Map<string, Deletion>;
  * @property {function} isMessageCopyable - Checks if a message content can be copied
  */
 export type ChatState = {
-    messages: Message[];
-    handleCachedMessage: (cachedMessage: CachedMessage) => void;
-    handleCachedMessages: (cachedMessages: CachedMessage[]) => void;
+    chatMessages: ChatMessage[];
+    handleMessage: (message: Message) => void;
+    handleMessages: (messages: Message[]) => void;
     clear: () => void;
-    findMessage: (id: string) => Message | undefined;
-    findReaction: (id: string) => Reaction | undefined;
-    findReplyToMessage: (message: Message) => Message | undefined;
+    findChatMessage: (id: string) => ChatMessage | undefined;
+    findReactionMessage: (id: string) => ReactionMessage | undefined;
+    findReplyToChatMessage: (chatMessage: ChatMessage) => ChatMessage | undefined;
     isDeleted: (eventId: string) => boolean;
     getMessageReactionsSummary: (messageId: string) => ReactionSummary[];
-    hasReactions: (message: Message) => boolean;
+    hasReactions: (message: ChatMessage) => boolean;
     clickReaction: (
         group: NostrMlsGroup,
         reaction: string,
         messageId: string
-    ) => Promise<CachedMessage | null>;
-    deleteMessage: (group: NostrMlsGroup, messageId: string) => Promise<CachedMessage | null>;
+    ) => Promise<Message | null>;
+    deleteMessage: (group: NostrMlsGroup, messageId: string) => Promise<Message | null>;
     payLightningInvoice: (
         groupWithRelays: NostrMlsGroupWithRelays,
-        message: Message
-    ) => Promise<CachedMessage | null>;
+        message: ChatMessage
+    ) => Promise<Message | null>;
     isMessageDeletable: (messageId: string) => boolean;
     isMessageCopyable: (messageId: string) => boolean;
 };

--- a/src/lib/utils/__tests__/deletion.test.ts
+++ b/src/lib/utils/__tests__/deletion.test.ts
@@ -1,67 +1,111 @@
-import type { NEvent } from "$lib/types/nostr";
+import type { Message } from "$lib/types/chat";
 import { describe, expect, it } from "vitest";
-import { eventToDeletion } from "../deletion";
+import { messageToDeletionMessage } from "../deletion";
 
-describe("eventToDeletion", () => {
+describe("messageToDeletionMessage", () => {
     describe("with valid target id in e tag", () => {
-        const event: NEvent = {
-            id: "deletion-event-id",
-            pubkey: "author-pubkey",
+        const message: Message = {
+            event_id: "deletion-event-id",
+            account_pubkey: "author-pubkey",
+            author_pubkey: "author-pubkey",
+            mls_group_id: "mls_group_id",
             created_at: 1234567890,
-            kind: 5,
-            tags: [
-                ["p", "some-pubkey"],
-                ["e", "target-event-id"],
-                ["other", "value"],
-            ],
+            event_kind: 5,
             content: "Delete this event",
-            sig: "signature",
+            outer_event_id: "outer_event_id",
+            tokens: [{ Text: "Delete this event" }],
+            event: {
+                id: "deletion-event-id",
+                pubkey: "author-pubkey",
+                created_at: 1234567890,
+                kind: 5,
+                tags: [
+                    ["p", "some-pubkey"],
+                    ["e", "target-event-id"],
+                    ["other", "value"],
+                ],
+                content: "Delete this event",
+                sig: "signature",
+            },
         };
-
         it("returns a valid Deletion object", () => {
-            const deletion = eventToDeletion(event);
+            const deletion = messageToDeletionMessage(message);
             expect(deletion).toEqual({
                 id: "deletion-event-id",
                 pubkey: "author-pubkey",
                 targetId: "target-event-id",
-                event: event,
+                event: {
+                    id: "deletion-event-id",
+                    pubkey: "author-pubkey",
+                    created_at: 1234567890,
+                    kind: 5,
+                    tags: [
+                        ["p", "some-pubkey"],
+                        ["e", "target-event-id"],
+                        ["other", "value"],
+                    ],
+                    content: "Delete this event",
+                    sig: "signature",
+                },
             });
         });
     });
 
     describe("without e tag", () => {
-        const event: NEvent = {
-            id: "deletion-event-id",
-            pubkey: "author-pubkey",
+        const message: Message = {
+            event_id: "deletion-event-id",
+            account_pubkey: "author-pubkey",
+            author_pubkey: "author-pubkey",
+            mls_group_id: "mls_group_id",
             created_at: 1234567890,
-            kind: 5,
-            tags: [
-                ["p", "some-pubkey"],
-                ["other", "value"],
-            ],
+            event_kind: 5,
             content: "Delete this event",
-            sig: "signature",
+            outer_event_id: "outer_event_id",
+            tokens: [{ Text: "Delete this event" }],
+            event: {
+                id: "deletion-event-id",
+                pubkey: "author-pubkey",
+                created_at: 1234567890,
+                kind: 5,
+                tags: [
+                    ["p", "some-pubkey"],
+                    ["other", "value"],
+                ],
+                content: "Delete this event",
+                sig: "signature",
+            },
         };
 
         it("returns null", () => {
-            const deletion = eventToDeletion(event);
+            const deletion = messageToDeletionMessage(message);
             expect(deletion).toBeNull();
         });
     });
 
     describe("with empty e tag", () => {
-        const event: NEvent = {
-            id: "deletion-event-id",
-            pubkey: "author-pubkey",
+        const message: Message = {
+            event_id: "deletion-event-id",
+            account_pubkey: "author-pubkey",
+            author_pubkey: "author-pubkey",
+            mls_group_id: "mls_group_id",
             created_at: 1234567890,
-            kind: 5,
-            tags: [["p", "some-pubkey"], ["e"], ["other", "value"]],
+            event_kind: 5,
             content: "Delete this event",
-            sig: "signature",
+            outer_event_id: "outer_event_id",
+            tokens: [{ Text: "Delete this event" }],
+            event: {
+                id: "deletion-event-id",
+                pubkey: "author-pubkey",
+                created_at: 1234567890,
+                kind: 5,
+                tags: [["p", "some-pubkey"], ["e"], ["other", "value"]],
+                content: "Delete this event",
+                sig: "signature",
+            },
         };
 
         it("returns null", () => {
-            const deletion = eventToDeletion(event);
+            const deletion = messageToDeletionMessage(message);
             expect(deletion).toBeNull();
         });
     });

--- a/src/lib/utils/__tests__/reaction.test.ts
+++ b/src/lib/utils/__tests__/reaction.test.ts
@@ -1,26 +1,37 @@
-import type { Reaction } from "$lib/types/chat";
+import type { Message } from "$lib/types/chat";
 import type { NEvent } from "$lib/types/nostr";
 import { describe, expect, it } from "vitest";
-import { eventToReaction } from "../reaction";
+import { messageToReactionMessage } from "../reaction";
 
-describe("eventToReaction", () => {
+describe("messageToReactionMessage", () => {
     describe("with valid target id", () => {
-        const event: NEvent = {
-            id: "test-id",
-            pubkey: "test-pubkey",
+        const message = {
+            event_id: "test-id",
+            account_pubkey: "test-pubkey",
+            author_pubkey: "test-pubkey",
+            mls_group_id: "mls_group_id",
             created_at: 1234567890,
-            kind: 7,
-            tags: [
-                ["p", "author-pubkey"],
-                ["e", "target-event-id"],
-                ["other", "value"],
-            ],
+            event_kind: 7,
             content: "👍",
-            sig: "signature",
+            outer_event_id: "outer_event_id",
+            tokens: [{ Text: "👍" }],
+            event: {
+                id: "test-id",
+                pubkey: "test-pubkey",
+                created_at: 1234567890,
+                kind: 7,
+                tags: [
+                    ["p", "author-pubkey"],
+                    ["e", "target-event-id"],
+                    ["other", "value"],
+                ],
+                content: "👍",
+                sig: "signature",
+            },
         };
 
         it("returns a Reaction object", () => {
-            const result = eventToReaction(event, "test-pubkey");
+            const result = messageToReactionMessage(message, "test-pubkey");
             expect(result).toEqual({
                 id: "test-id",
                 pubkey: "test-pubkey",
@@ -28,13 +39,25 @@ describe("eventToReaction", () => {
                 createdAt: 1234567890,
                 targetId: "target-event-id",
                 isMine: true,
-                event,
+                event: {
+                    id: "test-id",
+                    pubkey: "test-pubkey",
+                    created_at: 1234567890,
+                    kind: 7,
+                    tags: [
+                        ["p", "author-pubkey"],
+                        ["e", "target-event-id"],
+                        ["other", "value"],
+                    ],
+                    content: "👍",
+                    sig: "signature",
+                },
             });
         });
 
         describe("with a different pubkey", () => {
             it("isMine of reaction is false", () => {
-                const result = eventToReaction(event, "other-pubkey");
+                const result = messageToReactionMessage(message, "other-pubkey");
                 expect(result).toEqual({
                     id: "test-id",
                     pubkey: "test-pubkey",
@@ -42,7 +65,19 @@ describe("eventToReaction", () => {
                     createdAt: 1234567890,
                     targetId: "target-event-id",
                     isMine: false,
-                    event,
+                    event: {
+                        id: "test-id",
+                        pubkey: "test-pubkey",
+                        created_at: 1234567890,
+                        kind: 7,
+                        tags: [
+                            ["p", "author-pubkey"],
+                            ["e", "target-event-id"],
+                            ["other", "value"],
+                        ],
+                        content: "👍",
+                        sig: "signature",
+                    },
                 });
             });
         });
@@ -61,25 +96,58 @@ describe("eventToReaction", () => {
             content: "👍",
             sig: "signature",
         };
-
+        const message = {
+            event_id: "test-id",
+            account_pubkey: "test-pubkey",
+            author_pubkey: "test-pubkey",
+            mls_group_id: "mls_group_id",
+            created_at: 1234567890,
+            event_kind: 7,
+            content: "👍",
+            outer_event_id: "outer_event_id",
+            tokens: [{ Text: "👍" }],
+            event: {
+                id: "test-id",
+                pubkey: "test-pubkey",
+                created_at: 1234567890,
+                kind: 7,
+                tags: [
+                    ["p", "author-pubkey"],
+                    ["other", "value"],
+                ],
+                content: "👍",
+                sig: "signature",
+            },
+        };
         it("returns null", () => {
-            expect(eventToReaction(event, "test-pubkey")).toBeNull();
+            expect(messageToReactionMessage(message, "test-pubkey")).toBeNull();
         });
     });
 
     describe("with empty e tag", () => {
-        const event: NEvent = {
-            id: "test-id",
-            pubkey: "test-pubkey",
+        const message = {
+            event_id: "test-id",
+            account_pubkey: "test-pubkey",
+            author_pubkey: "test-pubkey",
+            mls_group_id: "mls_group_id",
             created_at: 1234567890,
-            kind: 7,
-            tags: [["p", "author-pubkey"], ["e"], ["other", "value"]],
+            event_kind: 7,
             content: "👍",
-            sig: "signature",
+            outer_event_id: "outer_event_id",
+            tokens: [{ Text: "👍" }],
+            event: {
+                id: "test-id",
+                pubkey: "test-pubkey",
+                created_at: 1234567890,
+                kind: 7,
+                tags: [["p", "author-pubkey"], ["e"], ["other", "value"]],
+                content: "👍",
+                sig: "signature",
+            },
         };
 
         it("returns null", () => {
-            expect(eventToReaction(event, "test-pubkey")).toBeNull();
+            expect(messageToReactionMessage(message, "test-pubkey")).toBeNull();
         });
     });
 });

--- a/src/lib/utils/deletion.ts
+++ b/src/lib/utils/deletion.ts
@@ -1,14 +1,14 @@
-import type { Deletion } from "$lib/types/chat";
-import type { NEvent } from "$lib/types/nostr";
+import type { DeletionMessage, Message } from "$lib/types/chat";
 import { findTargetId } from "./tags";
 
 /**
- * Converts a Nostr event to a Deletion object.
+ * Converts a Message to a DeletionMessage object.
  *
- * @param event - The Nostr event to convert
- * @returns A Deletion object or null if the event doesn't have a valid target ID
+ * @param message - The Message to convert
+ * @returns A DeletionMessage object or null if the message's event doesn't have a valid target ID
  */
-export function eventToDeletion(event: NEvent): Deletion | null {
+export function messageToDeletionMessage(message: Message): DeletionMessage | null {
+    const event = message.event;
     const targetId = findTargetId(event);
     if (!targetId) return null;
 

--- a/src/lib/utils/reaction.ts
+++ b/src/lib/utils/reaction.ts
@@ -1,15 +1,18 @@
-import type { Reaction } from "$lib/types/chat";
-import type { NEvent } from "$lib/types/nostr";
+import type { Message, ReactionMessage } from "$lib/types/chat";
 import { findTargetId } from "./tags";
 
 /**
- * Converts a Nostr event to a Reaction object.
+ * Converts a Nostr event to a ReactionMessage object.
  *
  * @param event - The Nostr event to convert
  * @param currentPubkey - The current user's public key, used to determine if the reaction belongs to the current user
- * @returns A Reaction object or null if the event doesn't have a valid target ID
+ * @returns A ReactionMessage object or null if the event doesn't have a valid target ID
  */
-export function eventToReaction(event: NEvent, currentPubkey: string | undefined): Reaction | null {
+export function messageToReactionMessage(
+    message: Message,
+    currentPubkey: string | undefined
+): ReactionMessage | null {
+    const event = message.event;
     const targetId = findTargetId(event);
     if (!targetId) return null;
     const isMine = currentPubkey === event.pubkey;

--- a/src/routes/(app)/chats/[id]/+page.svelte
+++ b/src/routes/(app)/chats/[id]/+page.svelte
@@ -425,20 +425,23 @@ function navigateToInfo() {
                         <OverflowMenuHorizontal size={24} />
                     </button>
                     <div
-                        use:press={()=>({ triggerBeforeFinished: true, timeframe: 100 })}
-                        onpress={handlePress}
                         data-message-container
                         data-message-id={chatMessage.id}
                         data-is-current-user={chatMessage.isMine}
                         class={`font-normal text-base relative rounded-md max-w-[70%] ${chatMessage.lightningPayment ? "bg-opacity-10" : ""} ${!chatMessage.isSingleEmoji ? `${chatMessage.isMine ? `bg-primary text-primary-foreground` : `bg-muted text-accent-foreground`} p-3` : ''} ${showMessageMenu && chatMessage.id === selectedMessageId ? 'relative z-20' : ''}`}
+                        id={chatMessage.id}
                     >
-                        {#if chatMessage.replyToId }
+                        {#if chatMessage.replyToId && !chatStore.isDeleted(chatMessage.id) }
                             <RepliedTo
                                 message={chatStore.findReplyToChatMessage(chatMessage)}
                                 isDeleted={chatStore.isDeleted(chatMessage.replyToId)}
                             />
                         {/if}
-                        <div class="flex {chatMessage.content.trim().length < 50 && !chatMessage.isSingleEmoji ? "flex-row gap-6" : "flex-col gap-2"} w-full {chatMessage.lightningPayment ? "items-center justify-center" : "items-end"}  {chatMessage.isSingleEmoji ? 'mb-4 my-6' : ''}">
+                        <div
+                            use:press={()=>({ triggerBeforeFinished: true, timeframe: 100 })}
+                            onpress={handlePress}
+                            class="flex {chatMessage.content.trim().length < 50 && !chatMessage.isSingleEmoji ? "flex-row gap-6" : "flex-col gap-2"} w-full {chatMessage.lightningPayment ? "items-center justify-center" : "items-end"}  {chatMessage.isSingleEmoji ? 'mb-4 my-6' : ''}"
+                        >
                             <div class="w-full {chatMessage.lightningPayment ? 'flex justify-center' : ''} {chatMessage.isSingleEmoji ? 'text-7xl leading-none' : ''}">
                                 {#if chatStore.isDeleted(chatMessage.id)}
                                     <div class="inline-flex flex-row items-center gap-2 px-3 py-1 w-fit text-muted-foreground">


### PR DESCRIPTION
# Context
While working on showing images, I found some translation issues and details that could be improved.

- Spanish translations had an issue in the main screen ({appName} looked awful) that I left there by mistake 😬 
<img width="100" alt="Captura de pantalla 2025-04-22 a la(s) 11 01 59 a m" src="https://github.com/user-attachments/assets/85fd9f90-51de-4e1c-9962-afaf764cdd79" />

- There was a visual bug with the three dots in the chat search. ("&hellip;")
<img width="341" alt="Captura de pantalla 2025-04-22 a la(s) 11 02 53 a m" src="https://github.com/user-attachments/assets/11913e24-ff80-4d70-8ebd-cd154087cce5" />

I also noticed some improvements possibilities in replies display, curious to hear what you think. 
- The replied-to message preview shows the full text, even when it is long. Other chat apps limit it  to 1–2 lines. I feel that showing the full text when it's long makes harder to read the reply without reading the replied to message

|whitenoise|telegram|whatsapp|signal|
|----|----|----|----|
|<img width="678" alt="master-reply-to-long-lmessage" src="https://github.com/user-attachments/assets/15a242d8-b145-41ba-851c-d898f4ba5409" />|<img width="465" alt="telegram reply to long message" src="https://github.com/user-attachments/assets/2d023b40-138f-43d1-9504-d7f77e9a60c7" />|<img width="487" alt="whatsapp reply to long messag" src="https://github.com/user-attachments/assets/e1a64883-46de-461a-8746-4666c1536a09" />|<img width="768" alt="Captura de pantalla 2025-04-22 a la(s) 11 39 21 a m" src="https://github.com/user-attachments/assets/9b366d91-d2d0-4479-a42b-0cb9c903bfbe" />|



- Deleted replies still show the original message preview.
<img width="400" alt="Captura de pantalla 2025-04-22 a la(s) 10 20 36 a m" src="https://github.com/user-attachments/assets/cb06bd45-ecac-49c0-9be4-54b9c6019ef0" />

- Replies  don't scroll to the original message.


# What has been done
- Translation issues were fixed.
- Message types in the frontend were renamed, based on [this conversation](https://github.com/parres-hq/whitenoise/pull/127#issuecomment-2752756677). Previous `CachedMessage` is now `Message`, previous `Message` is now `ChatMessage`, previous `Reaction` is now `ReactionMessage` and previous `Deletion` is now `DeletionMessage`.
- Reply display was (slightly) improved—let me know if you think they’re actually improvements 😅
   - The replied-to message is now limited to 2 lines.
   <img width="1095" alt="Captura de pantalla 2025-04-22 a la(s) 10 23 23 a m" src="https://github.com/user-attachments/assets/0340c995-d7a4-4eb8-8404-c195fe5d0e12" /> 
  
  - Deleted replies now appear just like any other deleted message, you can't see to which message was replying
    <img width="320" alt="Captura de pantalla 2025-04-22 a la(s) 10 23 13 a m" src="https://github.com/user-attachments/assets/a3f31ac3-afb1-44c4-8bc9-b80819c8247f" />

   - The reply preview now scrolls to the original message. (add video)

   https://github.com/user-attachments/assets/2f9df539-c670-4b72-8646-d26b824498e0



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Reply previews now display formatted message content with improved visual styling and support for multi-line truncation.
  - Clicking on a reply preview smoothly scrolls to the referenced message.

- **Bug Fixes**
  - Fixed message rendering in replies to prevent clickable links in reply previews.

- **Refactor**
  - Unified and clarified message, reaction, and deletion handling for improved consistency throughout chat features.
  - Updated internal message types and store methods for better maintainability.
  - Renamed and refined message-related types and methods for clearer distinction between generic messages and chat-specific messages.
  - Updated chat store and components to consistently use new message types and updated method signatures.

- **Style**
  - Enhanced reply message display with ellipsis truncation for long messages.
  - Removed trailing ellipses from certain chat search UI elements for cleaner text display.

- **Documentation**
  - Updated localization strings for multiple languages, adding new keys and refining existing messages for clarity and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->