### PR TITLE
chore(src-tauri/Cargo.lock): bump blurhash

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -668,9 +668,9 @@ dependencies = [
 
 [[package]]
 name = "blurhash"
-version = "0.1.1"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8671e4c8bf59f8784aa27fe4c8e152f2a45dfeb91a52d114e5d104a451494bb4"
+checksum = "e79769241dcd44edf79a732545e8b5cec84c247ac060f5252cd51885d093a8fc"
 
 [[package]]
 name = "brotli"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -20,7 +20,7 @@ tauri-build = { version = "2", features = [] }
 [dependencies]
 async-trait = "0.1.88"
 base64 = "0.22"
-blurhash = "0.1"
+blurhash = "0.2.3"
 chacha20poly1305 = "0.10"
 chrono = { version = "0.4.40", features = ["serde"] }
 hex = "0.4"

--- a/src-tauri/src/media/mod.rs
+++ b/src-tauri/src/media/mod.rs
@@ -222,7 +222,8 @@ fn generate_imeta_tag_values(
 
                 // Calculate blurhash
                 let rgb_img = img.to_rgba8().into_vec();
-                let blurhash = blurhash::encode(4, 3, width, height, &rgb_img);
+                let blurhash = blurhash::encode(4, 3, width, height, &rgb_img)
+                    .map_err(|e| format!("Failed to calculate blurhash: {}", e))?;
                 imeta_values.push(format!("blurhash {}", blurhash));
             }
             Err(e) => {


### PR DESCRIPTION
Fixes https://github.com/parres-hq/whitenoise/security/dependabot/4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling for image blurhash generation, ensuring failures are reported gracefully instead of causing unexpected crashes.

- **Chores**
  - Updated internal dependency for image blurhash processing to a newer version for enhanced stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->