### PR TITLE
fix(build): try to fix blurhash build issue

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -26,6 +26,12 @@ const excludes = [
 export default defineConfig(() => ({
     plugins: [sveltekit()],
 
+    build: {
+        rollupOptions: {
+            external: ["blurhash"],
+        },
+    },
+
     // Vite options tailored for Tauri development and only applied in `tauri dev` or `tauri build`
     //
     // 1. prevent vite from obscuring rust errors


### PR DESCRIPTION
## Context
The build is failing in master due to my last PR #174 
<img width="788" alt="Captura de pantalla 2025-05-20 a la(s) 1 00 59 p m" src="https://github.com/user-attachments/assets/6971ac89-a91e-493b-b32d-797c9cb89286" />

What’s strange is that the build works fine on my Mac. Here’s the error message from CI:


<img width="970" alt="Captura de pantalla 2025-05-20 a la(s) 1 01 43 p m" src="https://github.com/user-attachments/assets/6bca5eda-bed4-47e6-bdd3-c16cf2ef555e" />

## What has been done
Based on the error, it seems we need to explicitly treat blurhash as an external dependency. I’m not entirely sure why this is necessary, but I’ve applied the suggested fix to see if it resolves the issue.