### PR TITLE
feat(images): add sheet to show image in bigger size

### DIFF
--- a/src/lib/components/MediaImageSheet.svelte
+++ b/src/lib/components/MediaImageSheet.svelte
@@ -1,0 +1,33 @@
+<script lang="ts">
+import Sheet from "$lib/components/Sheet.svelte";
+import { _ as t } from "svelte-i18n";
+
+let {
+    isOpen = $bindable(false),
+    imageUrl,
+    alt,
+} = $props<{
+    isOpen: boolean;
+    imageUrl: string;
+    alt: string;
+}>();
+</script>
+
+<Sheet bind:open={isOpen} class="opacity-100">
+    {#snippet title()}
+        <span class="text-foreground px-2 text-base">
+            {$t("media.image")}
+        </span>
+    {/snippet}
+    <div class="relative w-full h-full flex items-center justify-center overflow-hidden">
+        <div class="w-full h-full flex items-center justify-center p-4">
+            <div class="relative w-full h-full flex items-center justify-center">
+                <img
+                    src={imageUrl}
+                    alt={alt}
+                    class="max-h-[70vh] rounded-lg object-contain"
+                />
+            </div>
+        </div>
+    </div>
+</Sheet> 

--- a/src/lib/components/MessageMediaAttachment.svelte
+++ b/src/lib/components/MessageMediaAttachment.svelte
@@ -6,6 +6,7 @@ import Close from "carbon-icons-svelte/lib/Close.svelte";
 import Download from "carbon-icons-svelte/lib/Download.svelte";
 import { _ as t } from "svelte-i18n";
 import Loader from "./Loader.svelte";
+import MediaImageSheet from "./MediaImageSheet.svelte";
 
 let { src, mediaAttachment, isInitialLoading, group, mediaStore, isMine } = $props<{
     src?: string;
@@ -18,7 +19,18 @@ let { src, mediaAttachment, isInitialLoading, group, mediaStore, isMine } = $pro
 
 let isDownloading = $state(isInitialLoading);
 let downloadFailed = $state(false);
+let isSheetOpen = $state(false);
 const showLoader = $derived((isDownloading || isInitialLoading) && !src);
+
+function handleImageClick() {
+    if (src) {
+        isSheetOpen = true;
+    }
+}
+
+function handleSheetClose() {
+    isSheetOpen = false;
+}
 
 $effect(() => {
     if (src && (isDownloading || isInitialLoading)) {
@@ -46,11 +58,16 @@ async function downloadMedia(mediaAttachment: MediaAttachment) {
 </script>
 <div class="relative">
   {#if mediaAttachment.type === "image"}
-    <img 
-      alt={mediaAttachment.alt} 
-      class="w-40 h-full rounded-lg aspect-square object-cover" 
-      src={src || mediaAttachment.blurhashSvg}
-    />
+    <button
+      onclick={handleImageClick}
+      class="max-w-40 h-full rounded-lg aspect-square overflow-hidden"
+    >
+      <img 
+        alt={mediaAttachment.alt} 
+        class="w-full h-full object-cover" 
+        src={src || mediaAttachment.blurhashSvg}
+      />
+    </button>
     {#if showLoader}
       <div
         class="absolute inset-0 flex items-center justify-center"
@@ -59,7 +76,7 @@ async function downloadMedia(mediaAttachment: MediaAttachment) {
           <Loader fullscreen={false} size={30} />
         </div>
       </div>
-    {:else if downloadFailed}
+    {:else if downloadFailed && !src}
       <div
         class="absolute inset-0 flex flex-col items-center justify-center gap-1"
       >
@@ -83,4 +100,12 @@ async function downloadMedia(mediaAttachment: MediaAttachment) {
     {/if}
   {/if}
 </div>
+
+{#if isSheetOpen}
+    <MediaImageSheet
+        bind:isOpen={isSheetOpen}
+        imageUrl={src}
+        alt={mediaAttachment.alt}
+    />
+{/if}
   

--- a/src/lib/locales/de.json
+++ b/src/lib/locales/de.json
@@ -170,6 +170,7 @@
         "error": "Zwischenablagefehler"
     },
     "media": {
-        "downloadError": "Download-Fehler"
+        "downloadError": "Download-Fehler",
+        "image": "Bild"
     }
 }

--- a/src/lib/locales/en.json
+++ b/src/lib/locales/en.json
@@ -170,6 +170,7 @@
         "error": "Clipboard error"
     },
     "media": {
-        "downloadError": "Download error"
+        "downloadError": "Download error",
+        "image": "Image"
     }
 }

--- a/src/lib/locales/es.json
+++ b/src/lib/locales/es.json
@@ -170,6 +170,7 @@
         "error": "Error del portapapeles"
     },
     "media": {
-        "downloadError": "Error de descarga"
+        "downloadError": "Error de descarga",
+        "image": "Imagen"
     }
 }

--- a/src/lib/locales/it.json
+++ b/src/lib/locales/it.json
@@ -170,6 +170,7 @@
         "error": "Errore appunti"
     },
     "media": {
-        "downloadError": "Errore di download"
+        "downloadError": "Errore di download",
+        "image": "Immagine"
     }
 }


### PR DESCRIPTION
# Context
Images were only visible squared and small

# What has been done
A sheet to show images in a bigger size was added


https://github.com/user-attachments/assets/8a9824a4-1570-477b-b2d9-fc5cb4e0be48

https://github.com/user-attachments/assets/b6c3b520-60d3-4dcd-86be-84c6956bf73d






<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an interactive image preview for media attachments, allowing users to view images in an overlay sheet by clicking on them.

- **Bug Fixes**
  - Improved error messaging for failed image downloads, now only shown when the image cannot be loaded.

- **Localization**
  - Added translations for "Image" in English, German, Spanish, and Italian.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->