### PR TITLE
Create subscriptions

### DIFF
--- a/src/nostr_manager/mod.rs
+++ b/src/nostr_manager/mod.rs
@@ -11,7 +11,7 @@ use tokio::sync::{mpsc::Sender, Mutex};
 pub mod parser;
 pub mod query;
 // pub mod search;
-// pub mod subscriptions;
+pub mod subscriptions;
 // pub mod sync;
 
 #[derive(Error, Debug)]

--- a/src/whitenoise.rs
+++ b/src/whitenoise.rs
@@ -276,14 +276,13 @@ impl Whitenoise {
         // Add the keys to the secret store
         self.secrets_store.store_private_key(&keys)?;
 
-        // TODO: initialize subs on nostr manager
-
         self.initialize_nostr_mls_for_account(&account).await?;
 
         // Onboard the account
         self.onboard_new_account(&mut account).await?;
 
-        // initialize subs on nostr manager
+        // Initialize subscriptions on nostr manager
+        self.setup_subscriptions(&account).await?;
 
         // Add the account to the in-memory accounts list
         self.accounts.insert(account.pubkey, account.clone());


### PR DESCRIPTION
This adds subscription bootstrapping on `create_identity` and `login`. Subscriptions have a custom sub_id that allows the event_processor to process the events for the right account as they come in. 

TODO: We still need to implement code that updates the subscriptions when we're creating new groups, when a user accepts an invite to a new group, or when their contact list changes. These will be handled in other PRs.