### PR TITLE
Add query and fetch methods for contacts, thoroughly test query and fetch

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,9 @@
+# Example environment variables for Whitenoise
+# Copy this file to .env and fill in your actual values
+
+# Your Nostr private key (nsec format) for contact fetching example
+# Get this from your Nostr client or generate a new one
+NOSTR_NSEC=nsec1...
+
+# Optional: Custom log level for debugging
+# RUST_LOG=debug

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4717,6 +4717,7 @@ dependencies = [
  "chrono",
  "clap",
  "derivative",
+ "dotenvy",
  "futures",
  "hex",
  "image",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 uuid = { version = "1.16.0", features = ["v4"] }
 base64ct = "=1.7.3"
 derivative = "2.2.0"
+dotenvy = "0.15"
 
 [target.'cfg(any(target_os = "ios", target_os = "macos"))'.dependencies]
 nostr-sdk = { version = "0.42", git="https://github.com/rust-nostr/nostr", rev = "c4d16c691f5bc03448cf95bb8b2f59f7d5d0ca79", features = [

--- a/src/nostr_manager/query.rs
+++ b/src/nostr_manager/query.rs
@@ -90,7 +90,10 @@ impl NostrManager {
             .author(pubkey)
             .limit(1);
 
-        let events = self.client.fetch_events(filter, self.timeout().await?).await?;
+        let events = self
+            .client
+            .fetch_events(filter, self.timeout().await?)
+            .await?;
 
         let contacts_pubkeys = if let Some(event) = events.first() {
             event

--- a/src/nostr_manager/query.rs
+++ b/src/nostr_manager/query.rs
@@ -90,7 +90,7 @@ impl NostrManager {
             .author(pubkey)
             .limit(1);
 
-        let events = self.client.database().query(filter).await?; // Keep this as database query for now while we want to check metadata
+        let events = self.client.fetch_events(filter, self.timeout().await?).await?;
 
         let contacts_pubkeys = if let Some(event) = events.first() {
             event

--- a/src/nostr_manager/query.rs
+++ b/src/nostr_manager/query.rs
@@ -59,10 +59,70 @@ impl NostrManager {
             vec![]
         };
 
+        if contacts_pubkeys.is_empty() {
+            return Ok(HashMap::new());
+        }
+
         let mut contacts_metadata = HashMap::new();
+        let meta_filter = Filter::new()
+            .kind(Kind::Metadata)
+            .authors(contacts_pubkeys.clone());
+        let meta_events = self.client.database().query(meta_filter).await?;
         for contact in contacts_pubkeys {
-            let metadata = self.fetch_user_metadata(contact).await?;
-            contacts_metadata.insert(contact, metadata);
+            let metadata_event = meta_events.iter().find(|e| e.pubkey == contact);
+            if let Some(metadata_event) = metadata_event {
+                contacts_metadata
+                    .insert(contact, Some(Metadata::from_json(&metadata_event.content)?));
+            } else {
+                contacts_metadata.insert(contact, None);
+            }
+        }
+
+        Ok(contacts_metadata)
+    }
+
+    pub(crate) async fn fetch_user_contact_list(
+        &self,
+        pubkey: PublicKey,
+    ) -> Result<HashMap<PublicKey, Option<Metadata>>> {
+        let filter = Filter::new()
+            .kind(Kind::ContactList)
+            .author(pubkey)
+            .limit(1);
+
+        let events = self.client.database().query(filter).await?; // Keep this as database query for now while we want to check metadata
+
+        let contacts_pubkeys = if let Some(event) = events.first() {
+            event
+                .tags
+                .iter()
+                .filter(|tag| tag.kind() == TagKind::p())
+                .filter_map(|tag| tag.content().map(|c| PublicKey::from_hex(c).unwrap()))
+                .collect()
+        } else {
+            vec![]
+        };
+
+        if contacts_pubkeys.is_empty() {
+            return Ok(HashMap::new());
+        }
+
+        let mut contacts_metadata = HashMap::new();
+        let meta_filter = Filter::new()
+            .kind(Kind::Metadata)
+            .authors(contacts_pubkeys.clone());
+        let meta_events = self
+            .client
+            .fetch_events(meta_filter, self.timeout().await?)
+            .await?;
+        for contact in contacts_pubkeys {
+            let metadata_event = meta_events.iter().find(|e| e.pubkey == contact);
+            if let Some(metadata_event) = metadata_event {
+                contacts_metadata
+                    .insert(contact, Some(Metadata::from_json(&metadata_event.content)?));
+            } else {
+                contacts_metadata.insert(contact, None);
+            }
         }
 
         Ok(contacts_metadata)

--- a/src/whitenoise/accounts/contacts.rs
+++ b/src/whitenoise/accounts/contacts.rs
@@ -40,6 +40,39 @@ impl Whitenoise {
             return Err(WhitenoiseError::AccountNotFound);
         }
 
+        let contacts = self.nostr.fetch_user_contact_list(pubkey).await?;
+        Ok(contacts)
+    }
+
+    /// Queries a user's contact list from local storage or cache.
+    ///
+    /// This method retrieves the user's contact list from local storage or cache first,
+    /// falling back to the network if necessary. This is more efficient than `fetch_contacts`
+    /// when the contact list may already be available locally. For each contact, it also
+    /// includes their metadata if available.
+    ///
+    /// # Arguments
+    ///
+    /// * `pubkey` - The `PublicKey` of the user whose contact list should be queried.
+    ///
+    /// # Returns
+    ///
+    /// Returns `Ok(HashMap<PublicKey, Option<Metadata>>)` where the keys are the public keys
+    /// of contacts and the values are their associated metadata (if available).
+    ///
+    /// # Errors
+    ///
+    /// Returns a `WhitenoiseError` if:
+    /// * The account is not logged in (`AccountNotFound`)
+    /// * The contact list query fails
+    pub async fn query_contacts(
+        &self,
+        pubkey: PublicKey,
+    ) -> Result<HashMap<PublicKey, Option<Metadata>>> {
+        if !self.logged_in(&pubkey).await {
+            return Err(WhitenoiseError::AccountNotFound);
+        }
+
         let contacts = self.nostr.query_user_contact_list(pubkey).await?;
         Ok(contacts)
     }


### PR DESCRIPTION
This adds distinct API method for using query (for local database cache querying) and fetch (for hitting relays) for contacts and their metadata. I've also added extensive testing and an example you can use to test real world usage with larger accounts. 

I'm quite sure that the API is returning the right metadata for the right for pubkeys. 