### PR TITLE
Remove nostrdb in favor of LMDB

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -294,29 +294,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d965446196e3b7decd44aa7ee49e31d630118f90ef12f97900f262eb915c951d"
 
 [[package]]
-name = "bindgen"
-version = "0.69.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
-dependencies = [
- "bitflags 2.9.0",
- "cexpr",
- "clang-sys",
- "itertools 0.12.1",
- "lazy_static",
- "lazycell",
- "log",
- "prettyplease",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash 1.1.0",
- "shlex",
- "syn 2.0.101",
- "which",
-]
-
-[[package]]
 name = "bip39"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -480,15 +457,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cexpr"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
-dependencies = [
- "nom",
-]
-
-[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -548,17 +516,6 @@ dependencies = [
  "crypto-common",
  "inout",
  "zeroize",
-]
-
-[[package]]
-name = "clang-sys"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
-dependencies = [
- "glob",
- "libc",
- "libloading",
 ]
 
 [[package]]
@@ -1055,11 +1012,11 @@ checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "flatbuffers"
-version = "23.5.26"
+version = "25.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dac53e22462d78c16d64a1cd22371b54cc3fe94aa15e7886a2fa6e5d1ab8640"
+checksum = "1045398c1bfd89168b5fd3f1fc11f6e70b34f6f66300c87d44d3de849463abf1"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.9.0",
  "rustc_version",
 ]
 
@@ -1268,12 +1225,6 @@ name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
-
-[[package]]
-name = "glob"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "gloo-timers"
@@ -1909,15 +1860,6 @@ checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itertools"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
@@ -1974,12 +1916,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
-
-[[package]]
 name = "lebe"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1990,16 +1926,6 @@ name = "libc"
 version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
-
-[[package]]
-name = "libloading"
-version = "0.8.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
-dependencies = [
- "cfg-if",
- "windows-targets 0.48.5",
-]
 
 [[package]]
 name = "libm"
@@ -2047,12 +1973,6 @@ dependencies = [
  "bitflags 2.9.0",
  "libc",
 ]
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.4.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -2147,12 +2067,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "minimal-lexical"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
 name = "miniz_oxide"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2204,19 +2118,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0efe882e02d206d8d279c20eb40e03baf7cb5136a1476dc084a324fbc3ec42d"
 
 [[package]]
-name = "nom"
-version = "7.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
-dependencies = [
- "memchr",
- "minimal-lexical",
-]
-
-[[package]]
 name = "nostr"
 version = "0.42.1"
-source = "git+https://github.com/rust-nostr/nostr?rev=c4d16c691f5bc03448cf95bb8b2f59f7d5d0ca79#c4d16c691f5bc03448cf95bb8b2f59f7d5d0ca79"
+source = "git+https://github.com/rust-nostr/nostr?rev=8b6a68a92b9e56728d6135169feb1bbec678e507#8b6a68a92b9e56728d6135169feb1bbec678e507"
 dependencies = [
  "aes",
  "base64 0.22.1",
@@ -2239,7 +2143,7 @@ dependencies = [
 [[package]]
 name = "nostr-blossom"
 version = "0.42.0"
-source = "git+https://github.com/rust-nostr/nostr?rev=c4d16c691f5bc03448cf95bb8b2f59f7d5d0ca79#c4d16c691f5bc03448cf95bb8b2f59f7d5d0ca79"
+source = "git+https://github.com/rust-nostr/nostr?rev=8b6a68a92b9e56728d6135169feb1bbec678e507#8b6a68a92b9e56728d6135169feb1bbec678e507"
 dependencies = [
  "base64 0.22.1",
  "nostr",
@@ -2250,7 +2154,7 @@ dependencies = [
 [[package]]
 name = "nostr-database"
 version = "0.42.0"
-source = "git+https://github.com/rust-nostr/nostr?rev=c4d16c691f5bc03448cf95bb8b2f59f7d5d0ca79#c4d16c691f5bc03448cf95bb8b2f59f7d5d0ca79"
+source = "git+https://github.com/rust-nostr/nostr?rev=8b6a68a92b9e56728d6135169feb1bbec678e507#8b6a68a92b9e56728d6135169feb1bbec678e507"
 dependencies = [
  "flatbuffers",
  "lru",
@@ -2261,7 +2165,7 @@ dependencies = [
 [[package]]
 name = "nostr-lmdb"
 version = "0.42.0"
-source = "git+https://github.com/rust-nostr/nostr?rev=c4d16c691f5bc03448cf95bb8b2f59f7d5d0ca79#c4d16c691f5bc03448cf95bb8b2f59f7d5d0ca79"
+source = "git+https://github.com/rust-nostr/nostr?rev=8b6a68a92b9e56728d6135169feb1bbec678e507#8b6a68a92b9e56728d6135169feb1bbec678e507"
 dependencies = [
  "async-utility",
  "heed",
@@ -2274,7 +2178,7 @@ dependencies = [
 [[package]]
 name = "nostr-mls"
 version = "0.42.0"
-source = "git+https://github.com/rust-nostr/nostr?rev=c4d16c691f5bc03448cf95bb8b2f59f7d5d0ca79#c4d16c691f5bc03448cf95bb8b2f59f7d5d0ca79"
+source = "git+https://github.com/rust-nostr/nostr?rev=8b6a68a92b9e56728d6135169feb1bbec678e507#8b6a68a92b9e56728d6135169feb1bbec678e507"
 dependencies = [
  "aes-gcm",
  "nostr",
@@ -2290,7 +2194,7 @@ dependencies = [
 [[package]]
 name = "nostr-mls-sqlite-storage"
 version = "0.42.0"
-source = "git+https://github.com/rust-nostr/nostr?rev=c4d16c691f5bc03448cf95bb8b2f59f7d5d0ca79#c4d16c691f5bc03448cf95bb8b2f59f7d5d0ca79"
+source = "git+https://github.com/rust-nostr/nostr?rev=8b6a68a92b9e56728d6135169feb1bbec678e507#8b6a68a92b9e56728d6135169feb1bbec678e507"
 dependencies = [
  "nostr",
  "nostr-mls-storage",
@@ -2306,7 +2210,7 @@ dependencies = [
 [[package]]
 name = "nostr-mls-storage"
 version = "0.42.0"
-source = "git+https://github.com/rust-nostr/nostr?rev=c4d16c691f5bc03448cf95bb8b2f59f7d5d0ca79#c4d16c691f5bc03448cf95bb8b2f59f7d5d0ca79"
+source = "git+https://github.com/rust-nostr/nostr?rev=8b6a68a92b9e56728d6135169feb1bbec678e507#8b6a68a92b9e56728d6135169feb1bbec678e507"
 dependencies = [
  "nostr",
  "openmls",
@@ -2316,19 +2220,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "nostr-ndb"
-version = "0.42.0"
-source = "git+https://github.com/rust-nostr/nostr?rev=c4d16c691f5bc03448cf95bb8b2f59f7d5d0ca79#c4d16c691f5bc03448cf95bb8b2f59f7d5d0ca79"
-dependencies = [
- "nostr",
- "nostr-database",
- "nostrdb",
-]
-
-[[package]]
 name = "nostr-relay-pool"
 version = "0.42.0"
-source = "git+https://github.com/rust-nostr/nostr?rev=c4d16c691f5bc03448cf95bb8b2f59f7d5d0ca79#c4d16c691f5bc03448cf95bb8b2f59f7d5d0ca79"
+source = "git+https://github.com/rust-nostr/nostr?rev=8b6a68a92b9e56728d6135169feb1bbec678e507#8b6a68a92b9e56728d6135169feb1bbec678e507"
 dependencies = [
  "async-utility",
  "async-wsocket",
@@ -2344,31 +2238,14 @@ dependencies = [
 [[package]]
 name = "nostr-sdk"
 version = "0.42.0"
-source = "git+https://github.com/rust-nostr/nostr?rev=c4d16c691f5bc03448cf95bb8b2f59f7d5d0ca79#c4d16c691f5bc03448cf95bb8b2f59f7d5d0ca79"
+source = "git+https://github.com/rust-nostr/nostr?rev=8b6a68a92b9e56728d6135169feb1bbec678e507#8b6a68a92b9e56728d6135169feb1bbec678e507"
 dependencies = [
  "async-utility",
  "nostr",
  "nostr-database",
  "nostr-lmdb",
- "nostr-ndb",
  "nostr-relay-pool",
  "tokio",
-]
-
-[[package]]
-name = "nostrdb"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df9b01d00781031ad2d6837a178e0e6ec343ff4ffc36a4510a583ed6cc67e159"
-dependencies = [
- "bindgen",
- "cc",
- "flatbuffers",
- "futures",
- "libc",
- "thiserror 2.0.12",
- "tokio",
- "tracing",
 ]
 
 [[package]]
@@ -2437,7 +2314,7 @@ dependencies = [
 [[package]]
 name = "nwc"
 version = "0.42.0"
-source = "git+https://github.com/rust-nostr/nostr?rev=c4d16c691f5bc03448cf95bb8b2f59f7d5d0ca79#c4d16c691f5bc03448cf95bb8b2f59f7d5d0ca79"
+source = "git+https://github.com/rust-nostr/nostr?rev=8b6a68a92b9e56728d6135169feb1bbec678e507#8b6a68a92b9e56728d6135169feb1bbec678e507"
 dependencies = [
  "async-utility",
  "nostr",
@@ -2661,7 +2538,7 @@ checksum = "9cd31dcfdbbd7431a807ef4df6edd6473228e94d5c805e8cf671227a21bad068"
 dependencies = [
  "anyhow",
  "clap",
- "itertools 0.14.0",
+ "itertools",
  "proc-macro2",
  "quote",
  "rand 0.8.5",
@@ -2800,16 +2677,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prettyplease"
-version = "0.2.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6837b9e10d61f45f987d50808f83d1ee3d206c66acf650c3e4ae2e1f6ddedf55"
-dependencies = [
- "proc-macro2",
- "syn 2.0.101",
-]
-
-[[package]]
 name = "primeorder"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2847,7 +2714,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "rustls 0.23.28",
  "socket2",
  "thiserror 2.0.12",
@@ -2867,7 +2734,7 @@ dependencies = [
  "lru-slab",
  "rand 0.9.1",
  "ring",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "rustls 0.23.28",
  "rustls-pki-types",
  "slab",
@@ -3233,12 +3100,6 @@ checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustc-hash"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
-
-[[package]]
-name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
@@ -3254,19 +3115,6 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
-dependencies = [
- "bitflags 2.9.0",
- "errno",
- "libc",
- "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "rustix"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d97817398dd4bb2e6da002002db259209759911da105da92bec29ccb12cf58bf"
@@ -3274,7 +3122,7 @@ dependencies = [
  "bitflags 2.9.0",
  "errno",
  "libc",
- "linux-raw-sys 0.9.4",
+ "linux-raw-sys",
  "windows-sys 0.59.0",
 ]
 
@@ -3971,7 +3819,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.2",
  "once_cell",
- "rustix 1.0.5",
+ "rustix",
  "windows-sys 0.59.0",
 ]
 
@@ -4691,18 +4539,6 @@ name = "weezl"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53a85b86a771b1c87058196170769dd264f66c0782acf1ae6cc51bfd64b39082"
-
-[[package]]
-name = "which"
-version = "4.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
-dependencies = [
- "either",
- "home",
- "once_cell",
- "rustix 0.38.44",
-]
 
 [[package]]
 name = "whitenoise"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,12 +28,18 @@ keyring = { version = "3.6", features = [
 ] }
 lightning-invoice = "0.33.1"
 
-nostr = { version = "0.42", git="https://github.com/rust-nostr/nostr", rev = "c4d16c691f5bc03448cf95bb8b2f59f7d5d0ca79", features = [ "std" ] }
-nostr-mls = { version = "0.42", git="https://github.com/rust-nostr/nostr", rev = "c4d16c691f5bc03448cf95bb8b2f59f7d5d0ca79" }
-nostr-mls-sqlite-storage = { version = "0.42", git="https://github.com/rust-nostr/nostr", rev = "c4d16c691f5bc03448cf95bb8b2f59f7d5d0ca79" }
-
-nwc = { version = "0.42", git="https://github.com/rust-nostr/nostr", rev = "c4d16c691f5bc03448cf95bb8b2f59f7d5d0ca79" }
-nostr-blossom = { version = "0.42", git="https://github.com/rust-nostr/nostr", rev = "c4d16c691f5bc03448cf95bb8b2f59f7d5d0ca79" }
+nostr = { version = "0.42", git="https://github.com/rust-nostr/nostr", rev = "8b6a68a92b9e56728d6135169feb1bbec678e507", features = [ "std" ] }
+nostr-mls = { version = "0.42", git="https://github.com/rust-nostr/nostr", rev = "8b6a68a92b9e56728d6135169feb1bbec678e507" }
+nostr-mls-sqlite-storage = { version = "0.42", git="https://github.com/rust-nostr/nostr", rev = "8b6a68a92b9e56728d6135169feb1bbec678e507" }
+nwc = { version = "0.42", git="https://github.com/rust-nostr/nostr", rev = "8b6a68a92b9e56728d6135169feb1bbec678e507" }
+nostr-blossom = { version = "0.42", git="https://github.com/rust-nostr/nostr", rev = "8b6a68a92b9e56728d6135169feb1bbec678e507" }
+nostr-sdk = { version = "0.42", git="https://github.com/rust-nostr/nostr", rev = "8b6a68a92b9e56728d6135169feb1bbec678e507", features = [
+    "lmdb",
+    "nip04",
+    "nip44",
+    "nip47",
+    "nip59",
+] }
 
 # LOCAL RUST_NOSTR FOR DEVELOPMENT
 # nostr = { version = "0.42", path="../rust-nostr/crates/nostr", features = [ "std" ] }
@@ -66,24 +72,6 @@ uuid = { version = "1.16.0", features = ["v4"] }
 base64ct = "=1.7.3"
 derivative = "2.2.0"
 dotenvy = "0.15"
-
-[target.'cfg(any(target_os = "ios", target_os = "macos"))'.dependencies]
-nostr-sdk = { version = "0.42", git="https://github.com/rust-nostr/nostr", rev = "c4d16c691f5bc03448cf95bb8b2f59f7d5d0ca79", features = [
-    "ndb",  # Use NDB for macOS and iOS
-    "nip04",
-    "nip44",
-    "nip47",
-    "nip59",
-] }
-
-[target.'cfg(not(any(target_os = "ios", target_os = "macos")))'.dependencies]
-nostr-sdk = { version = "0.42", git="https://github.com/rust-nostr/nostr", rev = "c4d16c691f5bc03448cf95bb8b2f59f7d5d0ca79", features = [
-    "lmdb",  # Use LMDB for all other platforms
-    "nip04",
-    "nip44",
-    "nip47",
-    "nip59",
-] }
 
 [dev-dependencies]
 mockito = "1.2"

--- a/examples/README.md
+++ b/examples/README.md
@@ -31,7 +31,7 @@ cargo run --example fetch_contacts_example
 - Relay connection status
 - API usage instructions
 
-### `onboarding_workflow.rs`  
+### `onboarding_workflow.rs`
 
 Demonstrates the complete onboarding workflow for new accounts.
 

--- a/examples/fetch_metadata_debug.rs
+++ b/examples/fetch_metadata_debug.rs
@@ -1,0 +1,405 @@
+use nostr_sdk::prelude::*;
+use std::path::PathBuf;
+use whitenoise::{Whitenoise, WhitenoiseConfig, WhitenoiseError};
+
+/// Example demonstrating how to fetch and compare metadata for two specific npubs
+///
+/// This example helps debug issues where different npubs are returning the same metadata.
+/// It fetches metadata for both provided npubs and performs detailed comparison of all fields.
+///
+/// To use this example:
+/// 1. Make sure you have a .env file with NOSTR_NSEC=your_private_key for authentication
+/// 2. Run: cargo run --example fetch_metadata_debug
+/// 3. The example will show detailed comparison of metadata for both npubs
+// Helper function to compare metadata and report differences
+fn compare_metadata(
+    npub1: &str,
+    metadata1: &Option<Metadata>,
+    npub2: &str,
+    metadata2: &Option<Metadata>,
+) -> (bool, Vec<String>) {
+    let mut differences = Vec::new();
+    let mut has_differences = false;
+
+    match (metadata1, metadata2) {
+        (Some(meta1), Some(meta2)) => {
+            // Compare name
+            if meta1.name != meta2.name {
+                differences.push(format!(
+                    "NAME differs: {} = {:?}, {} = {:?}",
+                    npub1, meta1.name, npub2, meta2.name
+                ));
+                has_differences = true;
+            }
+
+            // Compare display_name
+            if meta1.display_name != meta2.display_name {
+                differences.push(format!(
+                    "DISPLAY_NAME differs: {} = {:?}, {} = {:?}",
+                    npub1, meta1.display_name, npub2, meta2.display_name
+                ));
+                has_differences = true;
+            }
+
+            // Compare about
+            if meta1.about != meta2.about {
+                let about1_short = meta1.about.as_ref().map(|s| {
+                    if s.len() > 100 {
+                        format!("{}...", &s[..100])
+                    } else {
+                        s.clone()
+                    }
+                });
+                let about2_short = meta2.about.as_ref().map(|s| {
+                    if s.len() > 100 {
+                        format!("{}...", &s[..100])
+                    } else {
+                        s.clone()
+                    }
+                });
+                differences.push(format!(
+                    "ABOUT differs: {} = {:?}, {} = {:?}",
+                    npub1, about1_short, npub2, about2_short
+                ));
+                has_differences = true;
+            }
+
+            // Compare picture
+            if meta1.picture != meta2.picture {
+                differences.push(format!(
+                    "PICTURE differs: {} = {:?}, {} = {:?}",
+                    npub1, meta1.picture, npub2, meta2.picture
+                ));
+                has_differences = true;
+            }
+
+            // Compare banner
+            if meta1.banner != meta2.banner {
+                differences.push(format!(
+                    "BANNER differs: {} = {:?}, {} = {:?}",
+                    npub1, meta1.banner, npub2, meta2.banner
+                ));
+                has_differences = true;
+            }
+
+            // Compare nip05
+            if meta1.nip05 != meta2.nip05 {
+                differences.push(format!(
+                    "NIP05 differs: {} = {:?}, {} = {:?}",
+                    npub1, meta1.nip05, npub2, meta2.nip05
+                ));
+                has_differences = true;
+            }
+
+            // Compare lud16
+            if meta1.lud16 != meta2.lud16 {
+                differences.push(format!(
+                    "LUD16 differs: {} = {:?}, {} = {:?}",
+                    npub1, meta1.lud16, npub2, meta2.lud16
+                ));
+                has_differences = true;
+            }
+
+            // Compare website
+            if meta1.website != meta2.website {
+                differences.push(format!(
+                    "WEBSITE differs: {} = {:?}, {} = {:?}",
+                    npub1, meta1.website, npub2, meta2.website
+                ));
+                has_differences = true;
+            }
+
+            // If all fields are identical
+            if !has_differences {
+                differences.push(
+                    "⚠️  All metadata fields are IDENTICAL between the two npubs!".to_string(),
+                );
+                differences.push(
+                    "   This suggests there might be a caching issue or data corruption."
+                        .to_string(),
+                );
+            }
+        }
+        (Some(_), None) => {
+            differences.push(format!(
+                "AVAILABILITY: {} has metadata, {} has none",
+                npub1, npub2
+            ));
+            has_differences = true;
+        }
+        (None, Some(_)) => {
+            differences.push(format!(
+                "AVAILABILITY: {} has metadata, {} has none",
+                npub2, npub1
+            ));
+            has_differences = true;
+        }
+        (None, None) => {
+            differences.push("Both npubs have NO metadata available".to_string());
+        }
+    }
+
+    (has_differences, differences)
+}
+
+// Helper function to print detailed metadata
+fn print_metadata_details(npub: &str, metadata: &Option<Metadata>) {
+    match metadata {
+        Some(meta) => {
+            println!("📋 Metadata for {}:", npub);
+            println!("   • Name: {:?}", meta.name);
+            println!("   • Display Name: {:?}", meta.display_name);
+            if let Some(about) = &meta.about {
+                let about_short = if about.len() > 200 {
+                    format!("{}...", &about[..200])
+                } else {
+                    about.clone()
+                };
+                println!("   • About: {:?}", about_short);
+            } else {
+                println!("   • About: None");
+            }
+            println!("   • Picture: {:?}", meta.picture);
+            println!("   • Banner: {:?}", meta.banner);
+            println!("   • NIP05: {:?}", meta.nip05);
+            println!("   • LUD16: {:?}", meta.lud16);
+            println!("   • Website: {:?}", meta.website);
+        }
+        None => {
+            println!("📋 Metadata for {}: NONE", npub);
+        }
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), WhitenoiseError> {
+    // Delete the database
+    let db_path = PathBuf::from("dev/data/examples/data/nostr_lmdb");
+    if db_path.exists() {
+        std::fs::remove_dir_all(db_path).unwrap();
+    }
+
+    // Load environment variables from .env file if it exists
+    match dotenvy::dotenv() {
+        Ok(_) => println!("🔧 Loaded environment variables from .env file"),
+        Err(_) => println!("🔧 No .env file found, using system environment variables only"),
+    }
+
+    // Initialize Whitenoise with real configuration
+    let config = WhitenoiseConfig::new(
+        &PathBuf::from("dev/data/examples/data"),
+        &PathBuf::from("dev/data/examples/logs"),
+    );
+
+    println!("🔧 Initializing Whitenoise...");
+    Whitenoise::initialize_whitenoise(config).await?;
+    let whitenoise = Whitenoise::get_instance()?;
+
+    // Get the private key for authentication
+    let nsec = match std::env::var("NOSTR_NSEC") {
+        Ok(nsec) => {
+            println!("🔑 Using private key from NOSTR_NSEC environment variable");
+            nsec
+        }
+        Err(_) => {
+            println!("⚠️  No NOSTR_NSEC environment variable found.");
+            println!("   Creating a demo account instead.");
+            println!("   To use your real account:");
+            println!("   • Create a .env file with: NOSTR_NSEC=your_private_key");
+            println!("   • Or set environment variable: NOSTR_NSEC=your_private_key");
+            println!("   • Or run: NOSTR_NSEC=nsec1... cargo run --example fetch_metadata_debug");
+
+            // Generate a demo key for demonstration
+            let demo_keys = Keys::generate();
+            demo_keys.secret_key().to_secret_hex()
+        }
+    };
+
+    println!("\n🔑 Logging in with private key...");
+    let account = whitenoise.login(nsec).await?;
+
+    println!("✅ Successfully logged in!");
+    println!("   📊 Account pubkey: {}", account.pubkey.to_hex());
+    println!(
+        "   📡 Account npub: {}",
+        account
+            .pubkey
+            .to_bech32()
+            .unwrap_or_else(|_| "Invalid".to_string())
+    );
+
+    // Wait for background processing to complete
+    println!("\n⏳ Waiting 3 seconds for background processing to complete...");
+    tokio::time::sleep(tokio::time::Duration::from_secs(3)).await;
+
+    println!("\n🔍 METADATA COMPARISON DEBUG TEST");
+    println!("==================================");
+
+    // The two npubs to test
+    let npub1 = "npub1zymqqmvktw8lkr5dp6zzw5xk3fkdqcynj4l3f080k3amy28ses6setzznv";
+    let npub2 = "npub1zzmxvr9sw49lhzfx236aweurt8h5tmzjw7x3gfsazlgd8j64ql0sexw5wy";
+
+    println!("Testing npubs:");
+    println!("   📍 NPub 1: {}", npub1);
+    println!("   📍 NPub 2: {}", npub2);
+
+    // Convert npubs to PublicKey objects
+    let pubkey1 = match PublicKey::parse(npub1) {
+        Ok(pk) => pk,
+        Err(e) => {
+            eprintln!("❌ Failed to parse npub1: {}", e);
+            return Err(WhitenoiseError::InvalidPublicKey);
+        }
+    };
+
+    let pubkey2 = match PublicKey::parse(npub2) {
+        Ok(pk) => pk,
+        Err(e) => {
+            eprintln!("❌ Failed to parse npub2: {}", e);
+            return Err(WhitenoiseError::InvalidPublicKey);
+        }
+    };
+
+    // Verify they're different pubkeys
+    if pubkey1 == pubkey2 {
+        println!("❌ ERROR: Both npubs resolve to the same PublicKey!");
+        println!("   This would explain why metadata is identical.");
+        return Ok(());
+    } else {
+        println!("✅ Npubs resolve to different PublicKeys:");
+        println!("   📍 PubKey 1: {}", pubkey1.to_hex());
+        println!("   📍 PubKey 2: {}", pubkey2.to_hex());
+    }
+
+    println!("\n1️⃣  Fetching metadata for first npub...");
+    let start_time = std::time::Instant::now();
+    let metadata1 = whitenoise.fetch_metadata(pubkey1).await?;
+    let duration1 = start_time.elapsed();
+    println!("   ✅ Fetched in {:?}", duration1);
+
+    println!("\n2️⃣  Fetching metadata for second npub...");
+    let start_time = std::time::Instant::now();
+    let metadata2 = whitenoise.fetch_metadata(pubkey2).await?;
+    let duration2 = start_time.elapsed();
+    println!("   ✅ Fetched in {:?}", duration2);
+
+    // Print detailed metadata for both
+    println!("\n📊 DETAILED METADATA COMPARISON:");
+    println!("================================");
+
+    print_metadata_details(npub1, &metadata1);
+    println!();
+    print_metadata_details(npub2, &metadata2);
+
+    // Perform detailed comparison
+    println!("\n🔬 COMPARISON ANALYSIS:");
+    println!("======================");
+
+    let (has_differences, differences) = compare_metadata(npub1, &metadata1, npub2, &metadata2);
+
+    if has_differences {
+        println!(
+            "✅ GOOD! Found {} difference(s) between the metadata:",
+            differences.len()
+        );
+        for (i, diff) in differences.iter().enumerate() {
+            println!("   {}. {}", i + 1, diff);
+        }
+    } else {
+        println!("❌ PROBLEM DETECTED!");
+        for diff in differences {
+            println!("   {}", diff);
+        }
+    }
+
+    // Test cache consistency by fetching again
+    println!("\n🔄 CACHE CONSISTENCY TEST:");
+    println!("==========================");
+
+    println!("Re-fetching both metadata to check for caching issues...");
+
+    let metadata1_second = whitenoise.fetch_metadata(pubkey1).await?;
+    let metadata2_second = whitenoise.fetch_metadata(pubkey2).await?;
+
+    // Check if results are consistent between fetches
+    let consistent1 = match (&metadata1, &metadata1_second) {
+        (Some(m1), Some(m2)) => {
+            m1.name == m2.name
+                && m1.display_name == m2.display_name
+                && m1.about == m2.about
+                && m1.picture == m2.picture
+        }
+        (None, None) => true,
+        _ => false,
+    };
+
+    let consistent2 = match (&metadata2, &metadata2_second) {
+        (Some(m1), Some(m2)) => {
+            m1.name == m2.name
+                && m1.display_name == m2.display_name
+                && m1.about == m2.about
+                && m1.picture == m2.picture
+        }
+        (None, None) => true,
+        _ => false,
+    };
+
+    if consistent1 && consistent2 {
+        println!("✅ Cache consistency: Both npubs returned consistent metadata across fetches");
+    } else {
+        println!("❌ Cache inconsistency detected!");
+        if !consistent1 {
+            println!("   📍 {} metadata changed between fetches", npub1);
+        }
+        if !consistent2 {
+            println!("   📍 {} metadata changed between fetches", npub2);
+        }
+    }
+
+    println!("\n🎯 SUMMARY:");
+    println!("===========");
+
+    match (&metadata1, &metadata2) {
+        (Some(_), Some(_)) => {
+            if has_differences {
+                println!("✅ SUCCESS: Both npubs have metadata and they are DIFFERENT");
+                println!(
+                    "   This is the expected behavior - each user should have unique metadata."
+                );
+            } else {
+                println!("❌ ISSUE: Both npubs have metadata but it's IDENTICAL");
+                println!("   This suggests a potential bug in metadata fetching or caching.");
+                println!("   Possible causes:");
+                println!("   • Cache key collision");
+                println!("   • Database query returning wrong data");
+                println!("   • Relay data corruption");
+                println!("   • PublicKey parsing issue");
+            }
+        }
+        (Some(_), None) => {
+            println!("⚠️  PARTIAL: Only the first npub has metadata");
+            println!("   This could be normal if the second user hasn't published metadata.");
+        }
+        (None, Some(_)) => {
+            println!("⚠️  PARTIAL: Only the second npub has metadata");
+            println!("   This could be normal if the first user hasn't published metadata.");
+        }
+        (None, None) => {
+            println!("⚠️  NO DATA: Neither npub has metadata available");
+            println!("   This could indicate:");
+            println!("   • Users haven't published metadata");
+            println!("   • Relay connectivity issues");
+            println!("   • Database synchronization problems");
+        }
+    }
+
+    println!("\n⚡ PERFORMANCE SUMMARY:");
+    println!("   • First fetch: {:?}", duration1);
+    println!("   • Second fetch: {:?}", duration2);
+
+    if duration1.as_millis() > 1000 || duration2.as_millis() > 1000 {
+        println!("   ⚠️  Some fetches took longer than 1 second - possible network issues");
+    }
+
+    Ok(())
+}

--- a/examples/fetch_metadata_raw.rs
+++ b/examples/fetch_metadata_raw.rs
@@ -1,0 +1,111 @@
+use nostr_sdk::prelude::*;
+use std::path::PathBuf;
+use std::time::Duration;
+
+#[tokio::main]
+async fn main() {
+    let db_path = &PathBuf::from("dev/data/examples/fetch_metadata_raw");
+
+    // Delete the database
+    if db_path.exists() {
+        std::fs::remove_dir_all(db_path.clone()).unwrap();
+    }
+
+    let opts = ClientOptions::default();
+
+    let full_path = db_path.join("nostr_lmdb");
+    let db = NostrLMDB::builder(full_path)
+        .map_size(1024 * 1024 * 512)
+        .build()
+        .expect("Failed to open Nostr database");
+    let client = Client::builder().database(db).opts(opts).build();
+
+    let relays = vec![
+        "wss://relay.damus.io".to_string(),
+        "wss://relay.primal.net".to_string(),
+        "wss://nos.lol".to_string(),
+    ];
+
+    for relay in relays {
+        client.add_relay(relay).await.expect("Error adding relay");
+    }
+
+    client.connect().await;
+
+    let timeout = Duration::from_secs(3);
+    let jeff = PublicKey::parse("npub1zuuajd7u3sx8xu92yav9jwxpr839cs0kc3q6t56vd5u9q033xmhsk6c2uc")
+        .unwrap();
+    let wn_support =
+        PublicKey::parse("npub1zymqqmvktw8lkr5dp6zzw5xk3fkdqcynj4l3f080k3amy28ses6setzznv")
+            .unwrap();
+    let soapminer =
+        PublicKey::parse("npub1zzmxvr9sw49lhzfx236aweurt8h5tmzjw7x3gfsazlgd8j64ql0sexw5wy")
+            .unwrap();
+
+    let jeff_contacts = client
+        .fetch_events(
+            Filter::new().author(jeff).kind(Kind::ContactList).limit(1),
+            timeout,
+        )
+        .await
+        .expect("Error fetching contacts")
+        .first()
+        .unwrap()
+        .clone();
+
+    let jeff_contacts_pubkeys = jeff_contacts
+        .tags
+        .iter()
+        .filter(|tag| tag.kind() == TagKind::p())
+        .filter_map(|tag| tag.content().map(|c| PublicKey::from_hex(c).unwrap()))
+        .collect::<Vec<_>>();
+
+    println!(
+        "jeff_contacts_pubkeys length: {:?}",
+        jeff_contacts_pubkeys.len()
+    );
+
+    let metadata_filter = Filter::new()
+        .authors(jeff_contacts_pubkeys)
+        .kind(Kind::Metadata);
+
+    let _ = client
+        .fetch_events(metadata_filter, timeout)
+        .await
+        .expect("Error fetching metadata");
+
+    let wn_support_metadata = client
+        .database()
+        .query(Filter::new().author(wn_support).kind(Kind::Metadata))
+        .await
+        .expect("Error fetching metadata");
+    let soapminer_metadata = client
+        .database()
+        .query(Filter::new().author(soapminer).kind(Kind::Metadata))
+        .await
+        .expect("Error fetching metadata");
+
+    // Helper function to print metadata nicely
+    fn print_metadata(name: &str, events: &Events) {
+        if let Some(event) = events.first() {
+            match Metadata::from_json(&event.content) {
+                Ok(metadata) => {
+                    println!("=== {} Metadata ===", name);
+                    println!("Name: {:?}", metadata.name);
+                    println!("Display Name: {:?}", metadata.display_name);
+                    println!("About: {:?}", metadata.about);
+                    println!("Picture: {:?}", metadata.picture);
+                    println!("NIP-05: {:?}", metadata.nip05);
+                    println!("Website: {:?}", metadata.website);
+                    println!();
+                }
+                Err(e) => println!("Failed to parse {} metadata: {}", name, e),
+            }
+        } else {
+            println!("No {} metadata found", name);
+        }
+    }
+
+    print_metadata("WN Support", &wn_support_metadata);
+    print_metadata("Soapminer", &soapminer_metadata);
+}


### PR DESCRIPTION
I've been noticing lots of strange behavior with contact metadata fetching being attributed to the wrong npub. I finally narrowed it down and I believe that it's either nostrdb itself or the rust-nostr database wrapper. Since we have the ability to specify the map size with LMDB now, we've just simplified and we'll use that everywhere. 