### PR TITLE
Fix comments

### DIFF
--- a/db_migrations/0001_accounts.sql
+++ b/db_migrations/0001_accounts.sql
@@ -1,8 +1,7 @@
+-- Accounts table with JSON fields for complex objects
 CREATE TABLE accounts (
     pubkey TEXT PRIMARY KEY,
-    settings JSONB NOT NULL,
-    discovery_relays TEXT NOT NULL,
-    inbox_relays TEXT NOT NULL,
-    key_package_relays TEXT NOT NULL,
+    settings JSONB NOT NULL,  -- JSON AccountSettings
+    onboarding JSONB NOT NULL,  -- JSON AccountOnboarding
     last_synced INTEGER NOT NULL
 );

--- a/db_migrations/0003_contacts.sql
+++ b/db_migrations/0003_contacts.sql
@@ -1,7 +1,7 @@
 CREATE TABLE contacts (
     pubkey TEXT PRIMARY KEY NOT NULL,
     metadata TEXT,
-    discovery_relays TEXT NOT NULL,
+    nip65_relays TEXT NOT NULL,
     inbox_relays TEXT NOT NULL,
     key_package_relays TEXT NOT NULL
 );

--- a/db_migrations/0004_accounts_relays.sql
+++ b/db_migrations/0004_accounts_relays.sql
@@ -1,0 +1,35 @@
+-- Up Migration
+BEGIN;
+
+-- Step 1: Create a new temporary table with the updated schema
+CREATE TABLE accounts_new (
+    pubkey TEXT PRIMARY KEY,
+    settings JSONB NOT NULL,
+    discovery_relays TEXT NOT NULL,
+    inbox_relays TEXT NOT NULL,
+    key_package_relays TEXT NOT NULL,
+    last_synced INTEGER NOT NULL
+);
+
+-- Step 2: Copy data from old table to new table, with defaults for new columns
+INSERT INTO accounts_new (
+    pubkey, settings,
+    discovery_relays, inbox_relays, key_package_relays,
+    last_synced
+)
+SELECT
+    pubkey,
+    settings,
+    '[]',  -- default value for discovery_relays
+    '[]',  -- default value for inbox_relays
+    '[]',  -- default value for key_package_relays
+    last_synced
+FROM accounts;
+
+-- Step 3: Drop the old table
+DROP TABLE accounts;
+
+-- Step 4: Rename the new table to the original name
+ALTER TABLE accounts_new RENAME TO accounts;
+
+COMMIT;

--- a/db_migrations/0004_accounts_relays.sql
+++ b/db_migrations/0004_accounts_relays.sql
@@ -1,11 +1,8 @@
--- Up Migration
-BEGIN;
-
 -- Step 1: Create a new temporary table with the updated schema
 CREATE TABLE accounts_new (
     pubkey TEXT PRIMARY KEY,
     settings JSONB NOT NULL,
-    discovery_relays TEXT NOT NULL,
+    nip65_relays TEXT NOT NULL,
     inbox_relays TEXT NOT NULL,
     key_package_relays TEXT NOT NULL,
     last_synced INTEGER NOT NULL
@@ -14,13 +11,13 @@ CREATE TABLE accounts_new (
 -- Step 2: Copy data from old table to new table, with defaults for new columns
 INSERT INTO accounts_new (
     pubkey, settings,
-    discovery_relays, inbox_relays, key_package_relays,
+    nip65_relays, inbox_relays, key_package_relays,
     last_synced
 )
 SELECT
     pubkey,
     settings,
-    '[]',  -- default value for discovery_relays
+    '[]',  -- default value for nip65_relays
     '[]',  -- default value for inbox_relays
     '[]',  -- default value for key_package_relays
     last_synced
@@ -31,5 +28,3 @@ DROP TABLE accounts;
 
 -- Step 4: Rename the new table to the original name
 ALTER TABLE accounts_new RENAME TO accounts;
-
-COMMIT;

--- a/examples/fetch_contacts_example.rs
+++ b/examples/fetch_contacts_example.rs
@@ -221,7 +221,7 @@ async fn main() -> Result<(), WhitenoiseError> {
     // Test Method 2: fetch_contacts (relays)
     println!("\n2️⃣  Fetching contacts from relays using fetch_contacts...");
     let start_time = std::time::Instant::now();
-    let fetch_contacts = whitenoise.fetch_contacts(&account).await?;
+    let fetch_contacts = whitenoise.fetch_contacts(&account.pubkey).await?;
     let fetch_duration = start_time.elapsed();
 
     let fetch_with_metadata = fetch_contacts

--- a/examples/fetch_metadata_debug.rs
+++ b/examples/fetch_metadata_debug.rs
@@ -271,12 +271,12 @@ async fn main() -> Result<(), WhitenoiseError> {
         println!("   📍 PubKey 2: {}", pubkey2.to_hex());
     }
 
-    let discovery_relays = Account::default_relays();
+    let nip65_relays = Account::default_relays();
 
     println!("\n1️⃣  Fetching metadata for first npub...");
     let start_time = std::time::Instant::now();
     let metadata1 = whitenoise
-        .fetch_metadata_from(discovery_relays.clone(), pubkey1)
+        .fetch_metadata_from(nip65_relays.clone(), pubkey1)
         .await?;
     let duration1 = start_time.elapsed();
     println!("   ✅ Fetched in {:?}", duration1);
@@ -284,7 +284,7 @@ async fn main() -> Result<(), WhitenoiseError> {
     println!("\n2️⃣  Fetching metadata for second npub...");
     let start_time = std::time::Instant::now();
     let metadata2 = whitenoise
-        .fetch_metadata_from(discovery_relays.clone(), pubkey2)
+        .fetch_metadata_from(nip65_relays.clone(), pubkey2)
         .await?;
     let duration2 = start_time.elapsed();
     println!("   ✅ Fetched in {:?}", duration2);
@@ -325,10 +325,10 @@ async fn main() -> Result<(), WhitenoiseError> {
     println!("Re-fetching both metadata to check for caching issues...");
 
     let metadata1_second = whitenoise
-        .fetch_metadata_from(discovery_relays.clone(), pubkey1)
+        .fetch_metadata_from(nip65_relays.clone(), pubkey1)
         .await?;
     let metadata2_second = whitenoise
-        .fetch_metadata_from(discovery_relays.clone(), pubkey2)
+        .fetch_metadata_from(nip65_relays.clone(), pubkey2)
         .await?;
 
     // Check if results are consistent between fetches

--- a/message-aggr-plan.md
+++ b/message-aggr-plan.md
@@ -497,7 +497,7 @@ impl Whitenoise {
     ) -> Result<Vec<ChatMessage>> {
         // Get account to access nostr_mls instance
         let account = self.fetch_account(pubkey).await?;
-        let nostr_mls_guard = account.nostr_mls.lock().await;
+        let nostr_mls_guard = account.nostr_mls.lock().unwrap();
         
         if let Some(nostr_mls) = nostr_mls_guard.as_ref() {
             // Use the aggregator to handle the complete pipeline

--- a/src/bin/integration_test.rs
+++ b/src/bin/integration_test.rs
@@ -125,7 +125,7 @@ async fn main() -> Result<(), WhitenoiseError> {
     // Test metadata fetching
     tracing::info!("Testing metadata fetching...");
     let loaded_metadata = whitenoise
-        .fetch_metadata_from(account3.discovery_relays.clone(), account3.pubkey)
+        .fetch_metadata_from(account3.nip65_relays.clone(), account3.pubkey)
         .await?;
     if let Some(metadata) = loaded_metadata {
         assert_eq!(metadata.name, Some("Known User".to_string()));

--- a/src/bin/integration_test.rs
+++ b/src/bin/integration_test.rs
@@ -196,7 +196,7 @@ async fn main() -> Result<(), WhitenoiseError> {
     let test_contact3 = Keys::generate().public_key();
 
     // Test initial empty contact list
-    let initial_contacts = whitenoise.fetch_contacts(&account1).await?;
+    let initial_contacts = whitenoise.fetch_contacts(&account1.pubkey).await?;
     assert_eq!(initial_contacts.len(), 0);
     tracing::info!("✓ Initial contact list is empty");
 

--- a/src/media/mod.rs
+++ b/src/media/mod.rs
@@ -83,7 +83,7 @@ pub async fn add_media_file(
 
     // Get the raw secret key bytes
     let exporter_secret: group_types::GroupExporterSecret;
-    let nostr_mls_guard = wn.nostr_mls.lock().await;
+    let nostr_mls_guard = wn.nostr_mls.lock().unwrap();
     if let Some(nostr_mls) = nostr_mls_guard.as_ref() {
         exporter_secret = nostr_mls
             .exporter_secret(&group.mls_group_id)

--- a/src/nostr_manager/query.rs
+++ b/src/nostr_manager/query.rs
@@ -15,13 +15,13 @@ impl NostrManager {
 
     pub(crate) async fn fetch_metadata_from(
         &self,
-        discovery_relays: Vec<RelayUrl>,
+        nip65_relays: Vec<RelayUrl>,
         pubkey: PublicKey,
     ) -> Result<Option<Metadata>> {
         let filter: Filter = Filter::new().author(pubkey).kind(Kind::Metadata).limit(1);
         let events: Events = self
             .client
-            .fetch_events_from(discovery_relays, filter, self.timeout)
+            .fetch_events_from(nip65_relays, filter, self.timeout)
             .await?;
         match events.first() {
             Some(event) => Ok(Some(Metadata::try_from(event)?)),
@@ -33,7 +33,7 @@ impl NostrManager {
         &self,
         pubkey: PublicKey,
         relay_type: RelayType,
-        discovery_relays: Vec<RelayUrl>,
+        nip65_relays: Vec<RelayUrl>,
     ) -> Result<Vec<RelayUrl>> {
         let filter = Filter::new()
             .author(pubkey)
@@ -41,7 +41,7 @@ impl NostrManager {
             .limit(1);
         let relay_events = self
             .client
-            .fetch_events_from(discovery_relays, filter.clone(), self.timeout)
+            .fetch_events_from(nip65_relays, filter.clone(), self.timeout)
             .await?;
         Ok(Self::relay_urls_from_events(relay_events))
     }
@@ -102,7 +102,7 @@ impl NostrManager {
 
         let events = self
             .client
-            .fetch_events_from(account.discovery_relays.clone(), filter, self.timeout)
+            .fetch_events_from(account.nip65_relays.clone(), filter, self.timeout)
             .await?;
 
         let mut contacts_pubkeys: HashSet<_> = if let Some(event) = events.first() {

--- a/src/whitenoise/accounts/contacts.rs
+++ b/src/whitenoise/accounts/contacts.rs
@@ -200,11 +200,21 @@ impl Whitenoise {
         let metadata = self
             .fetch_metadata_from(account.nip65_relays.clone(), contact_pubkey)
             .await?;
+        let mut nip65_relays = self
+            .fetch_relays_from(
+                account.nip65_relays.clone(),
+                contact_pubkey,
+                RelayType::Nostr,
+            )
+            .await?;
+        if nip65_relays.is_empty() {
+            nip65_relays = account.nip65_relays.clone();
+        }
 
         // save contact locally
         let contact = Contact {
             pubkey: contact_pubkey,
-            nip65_relays: account.nip65_relays.clone(), // The account discovered the contact through this relays
+            nip65_relays,
             inbox_relays,
             key_package_relays,
             metadata,

--- a/src/whitenoise/accounts/groups.rs
+++ b/src/whitenoise/accounts/groups.rs
@@ -43,10 +43,6 @@ impl Whitenoise {
         let mut key_package_events: Vec<Event> = Vec::new();
         let mut contacts = Vec::new();
 
-        let nostr_mls = &*creator_account.nostr_mls.lock().await;
-        let group_relays = config.relays.clone();
-
-        // Fetch key packages for all members
         for pk in member_pubkeys.iter() {
             let contact = self.load_contact(pk).await?;
             let some_event = self
@@ -59,14 +55,32 @@ impl Whitenoise {
             contacts.push(contact);
         }
 
-        let create_group_result = nostr_mls
-            .create_group(
-                &creator_account.pubkey,
-                key_package_events.clone(),
-                admin_pubkeys,
-                config,
-            )
-            .map_err(WhitenoiseError::from)?;
+        let group_relays = config.relays.clone();
+
+        let (create_group_result, group_ids) = tokio::task::spawn_blocking({
+            let creator_account = creator_account.clone();
+            let key_package_events = key_package_events.clone();
+            move || -> core::result::Result<_, nostr_mls::error::Error> {
+                let nostr_mls = creator_account.nostr_mls.lock().unwrap();
+                // Fetch key packages for all members
+                let create_group_result = nostr_mls.create_group(
+                    &creator_account.pubkey,
+                    key_package_events,
+                    admin_pubkeys,
+                    config,
+                )?;
+
+                let group_ids = nostr_mls
+                    .get_groups()?
+                    .into_iter()
+                    .map(|g| hex::encode(g.nostr_group_id))
+                    .collect::<Vec<_>>();
+
+                Ok((create_group_result, group_ids))
+            }
+        })
+        .await
+        .map_err(WhitenoiseError::from)??;
 
         let group = create_group_result.group;
         let welcome_rumors = create_group_result.welcome_rumors;
@@ -75,8 +89,6 @@ impl Whitenoise {
                 "Welcome rumours are missing for some of the members",
             )));
         }
-
-        tracing::debug!(target: "whitenoise::commands::groups::create_group", "nostr_mls lock released");
 
         // Fan out the welcome message to all members
         for (welcome_rumor, contact) in welcome_rumors.iter().zip(contacts.iter()) {
@@ -113,13 +125,6 @@ impl Whitenoise {
                 .map_err(WhitenoiseError::from)?;
         }
 
-        let group_ids = nostr_mls
-            .get_groups()
-            .map_err(WhitenoiseError::from)?
-            .into_iter()
-            .map(|g| hex::encode(g.nostr_group_id))
-            .collect::<Vec<_>>();
-
         self.nostr
             .setup_group_messages_subscriptions_with_signer(
                 creator_account.pubkey,
@@ -142,7 +147,7 @@ impl Whitenoise {
             return Err(WhitenoiseError::AccountNotFound);
         }
 
-        let nostr_mls = &*account.nostr_mls.lock().await;
+        let nostr_mls = &*account.nostr_mls.lock().unwrap();
         Ok(nostr_mls
             .get_groups()
             .map_err(WhitenoiseError::from)?
@@ -160,7 +165,7 @@ impl Whitenoise {
             return Err(WhitenoiseError::AccountNotFound);
         }
 
-        let nostr_mls = &*account.nostr_mls.lock().await;
+        let nostr_mls = &*account.nostr_mls.lock().unwrap();
         Ok(nostr_mls
             .get_members(group_id)
             .map_err(WhitenoiseError::from)?
@@ -177,7 +182,7 @@ impl Whitenoise {
             return Err(WhitenoiseError::AccountNotFound);
         }
 
-        let nostr_mls = &*account.nostr_mls.lock().await;
+        let nostr_mls = &*account.nostr_mls.lock().unwrap();
         Ok(nostr_mls
             .get_group(group_id)
             .map_err(WhitenoiseError::from)?
@@ -233,7 +238,6 @@ impl Whitenoise {
             .get_nostr_keys_for_pubkey(&account.pubkey)?;
         let mut contacts = Vec::new();
 
-        let nostr_mls = &*account.nostr_mls.lock().await;
         // Fetch key packages for all members
         for pk in members.iter() {
             let contact = self.load_contact(pk).await?;
@@ -247,9 +251,25 @@ impl Whitenoise {
             contacts.push(contact);
         }
 
-        let update_result = nostr_mls
-            .add_members(group_id, &key_package_events)
-            .map_err(WhitenoiseError::from)?;
+        let (update_result, group_relays) = tokio::task::spawn_blocking({
+            let key_package_events = key_package_events.clone();
+            let account = account.clone();
+            let group_id = group_id.clone();
+            move || -> core::result::Result<_, nostr_mls::error::Error> {
+                let nostr_mls = account.nostr_mls.lock().unwrap();
+                let update_result = nostr_mls.add_members(&group_id, &key_package_events)?;
+                // Merge the pending commit immediately after creating it
+                // This ensures our local state is correct before publishing
+                nostr_mls.merge_pending_commit(&group_id)?;
+
+                // Publish the evolution event to the group
+                let group_relays = nostr_mls.get_relays(&group_id)?;
+
+                Ok((update_result, group_relays))
+            }
+        })
+        .await??;
+
         let evolution_event = update_result.evolution_event;
 
         let welcome_rumors = match update_result.welcome_rumors {
@@ -267,16 +287,6 @@ impl Whitenoise {
             )));
         }
 
-        // Merge the pending commit immediately after creating it
-        // This ensures our local state is correct before publishing
-        nostr_mls
-            .merge_pending_commit(group_id)
-            .map_err(WhitenoiseError::from)?;
-
-        // Publish the evolution event to the group
-        let group_relays = nostr_mls
-            .get_relays(group_id)
-            .map_err(WhitenoiseError::from)?;
         let result = self
             .nostr
             .publish_event_to(evolution_event, &group_relays)
@@ -364,37 +374,24 @@ impl Whitenoise {
         group_id: &GroupId,
         members: Vec<PublicKey>,
     ) -> Result<()> {
-        let evolution_event: Event;
-        let nostr_mls = &*account.nostr_mls.lock().await;
+        let (update_result, group_relays) = tokio::task::spawn_blocking({
+            let account = account.clone();
+            let group_id = group_id.clone();
+            move || -> core::result::Result<_, nostr_mls::error::Error> {
+                let nostr_mls = account.nostr_mls.lock().unwrap();
 
-        // First, validate that all members to be removed are actually in the group
-        let current_members = nostr_mls
-            .get_members(group_id)
-            .map_err(WhitenoiseError::from)?
-            .into_iter()
-            .collect::<std::collections::HashSet<PublicKey>>();
+                let update_result = nostr_mls.remove_members(&group_id, &members)?;
 
-        let mut members_not_in_group = Vec::new();
-        for member in &members {
-            if !current_members.contains(member) {
-                members_not_in_group.push(*member);
+                nostr_mls.merge_pending_commit(&group_id)?;
+
+                let group_relays = nostr_mls.get_relays(&group_id)?;
+
+                Ok((update_result, group_relays))
             }
-        }
+        })
+        .await??;
 
-        if !members_not_in_group.is_empty() {
-            return Err(WhitenoiseError::MembersNotInGroup);
-        }
-        let update_result = nostr_mls.remove_members(group_id, &members)?;
-        evolution_event = update_result.evolution_event;
-
-        nostr_mls
-            .merge_pending_commit(group_id)
-            .map_err(WhitenoiseError::from)?;
-
-        let group_relays = nostr_mls
-            .get_relays(group_id)
-            .map_err(WhitenoiseError::from)?;
-
+        let evolution_event = update_result.evolution_event;
         self.nostr
             .publish_event_to(evolution_event, &group_relays)
             .await?;

--- a/src/whitenoise/accounts/mod.rs
+++ b/src/whitenoise/accounts/mod.rs
@@ -638,7 +638,7 @@ impl Whitenoise {
 
         let mut txn = self.database.pool.begin().await?;
 
-        let discovery_urls: Vec<_> = account
+        let nip65_urls: Vec<_> = account
             .nip65_relays
             .iter()
             .map(|relay_url| relay_url.as_str())
@@ -666,7 +666,7 @@ impl Whitenoise {
         )
         .bind(account.pubkey.to_hex())
         .bind(&serde_json::to_string(&account.settings)?)
-        .bind(&serde_json::to_string(&discovery_urls)?)
+        .bind(&serde_json::to_string(&nip65_urls)?)
         .bind(&serde_json::to_string(&inbox_urls)?)
         .bind(&serde_json::to_string(&key_package_urls)?)
         .bind(account.last_synced.to_string())

--- a/src/whitenoise/accounts/mod.rs
+++ b/src/whitenoise/accounts/mod.rs
@@ -279,6 +279,8 @@ impl Whitenoise {
             Err(e) => return Err(e),
         };
 
+        self.connect_account_relays(&account).await?;
+
         // Add the account to the in-memory accounts list
         {
             let mut accounts = self.write_accounts().await;

--- a/src/whitenoise/accounts/mod.rs
+++ b/src/whitenoise/accounts/mod.rs
@@ -574,12 +574,19 @@ impl Whitenoise {
         })?;
         tracing::debug!(target: "whitenoise::add_account_from_keys", "Keys stored in secret store");
 
+        let mut nip65_relays = self
+            .fetch_relays_from(Account::default_relays(), keys.public_key, RelayType::Nostr)
+            .await?;
+        if nip65_relays.is_empty() {
+            nip65_relays = Account::default_relays();
+        }
+
         // Step 3: Create account struct and save to database
         let account = Account {
             pubkey: keys.public_key(),
             settings: AccountSettings::default(),
             last_synced: Timestamp::zero(),
-            nip65_relays: Account::default_relays(),
+            nip65_relays,
             inbox_relays: Account::default_relays(),
             key_package_relays: Account::default_relays(),
             nostr_mls: Account::create_nostr_mls(keys.public_key(), &self.config.data_dir)?,

--- a/src/whitenoise/accounts/relays.rs
+++ b/src/whitenoise/accounts/relays.rs
@@ -132,4 +132,25 @@ impl Whitenoise {
 
         Ok(relay_statuses)
     }
+
+    pub(crate) async fn connect_account_relays(&self, account: &Account) -> Result<()> {
+        for relay in account
+            .nip65_relays
+            .iter()
+            .chain(account.inbox_relays.iter())
+            .chain(account.key_package_relays.iter())
+        {
+            self.nostr.client.add_relay(relay).await?;
+        }
+
+        tracing::debug!("Connecting to the account relays added");
+        tokio::spawn({
+            let client = self.nostr.client.clone();
+            async move {
+                client.connect().await;
+            }
+        });
+
+        Ok(())
+    }
 }

--- a/src/whitenoise/accounts/relays.rs
+++ b/src/whitenoise/accounts/relays.rs
@@ -63,13 +63,13 @@ impl Whitenoise {
     /// Returns a `WhitenoiseError` if the relay query fails.
     pub async fn fetch_relays_from(
         &self,
-        discovery_relays: Vec<RelayUrl>,
+        nip65_relays: Vec<RelayUrl>,
         pubkey: PublicKey,
         relay_type: RelayType,
     ) -> Result<Vec<RelayUrl>> {
         let relays = self
             .nostr
-            .fetch_user_relays(pubkey, relay_type, discovery_relays)
+            .fetch_user_relays(pubkey, relay_type, nip65_relays)
             .await?;
         Ok(relays)
     }
@@ -110,7 +110,7 @@ impl Whitenoise {
         // Get all relay URLs for this user across all types
         // Combine all relay URLs into one list, removing duplicates
         let mut all_relays = Vec::new();
-        all_relays.extend(account.discovery_relays.clone());
+        all_relays.extend(account.nip65_relays.clone());
         all_relays.extend(account.inbox_relays.clone());
         all_relays.extend(account.key_package_relays.clone());
 

--- a/src/whitenoise/accounts/relays.rs
+++ b/src/whitenoise/accounts/relays.rs
@@ -138,7 +138,6 @@ impl Whitenoise {
             .nip65_relays
             .iter()
             .chain(account.inbox_relays.iter())
-            .chain(account.key_package_relays.iter())
         {
             self.nostr.client.add_relay(relay).await?;
         }

--- a/src/whitenoise/database.rs
+++ b/src/whitenoise/database.rs
@@ -19,7 +19,7 @@ const MIGRATION_FILES: &[(&str, &[u8])] = &[
         include_bytes!("../../db_migrations/0003_contacts.sql"),
     ),
     (
-        "0001_accounts_relays.sql",
+        "0004_accounts_relays.sql",
         include_bytes!("../../db_migrations/0004_accounts_relays.sql"),
     ),
     // Add new migrations here in order, for example:
@@ -276,7 +276,7 @@ mod tests {
         let (db, _temp_dir) = create_test_db().await;
 
         // Insert some test data
-        sqlx::query("INSERT INTO accounts (pubkey, settings, discovery_relays, inbox_relays, key_package_relays, last_synced) VALUES ('test-pubkey', '{}', '[1,2]', '[]', '[1]', 0)")
+        sqlx::query("INSERT INTO accounts (pubkey, settings, nip65_relays, inbox_relays, key_package_relays, last_synced) VALUES ('test-pubkey', '{}', '[1,2]', '[]', '[1]', 0)")
             .execute(&db.pool)
             .await
             .expect("Failed to insert test account");
@@ -351,7 +351,7 @@ mod tests {
             .expect("Failed to create database");
 
         // Insert some data
-        sqlx::query("INSERT INTO accounts (pubkey, settings, discovery_relays, inbox_relays, key_package_relays, last_synced) VALUES ('test-pubkey', '{}', '[1,2]', '[]', '[1]', 0)")
+        sqlx::query("INSERT INTO accounts (pubkey, settings, nip65_relays, inbox_relays, key_package_relays, last_synced) VALUES ('test-pubkey', '{}', '[1,2]', '[]', '[1]', 0)")
             .execute(&db1.pool)
             .await
             .expect("Failed to insert test data");

--- a/src/whitenoise/database.rs
+++ b/src/whitenoise/database.rs
@@ -18,6 +18,10 @@ const MIGRATION_FILES: &[(&str, &[u8])] = &[
         "0003_contacts.sql",
         include_bytes!("../../db_migrations/0003_contacts.sql"),
     ),
+    (
+        "0001_accounts_relays.sql",
+        include_bytes!("../../db_migrations/0004_accounts_relays.sql"),
+    ),
     // Add new migrations here in order, for example:
     // ("000X_something.sql", include_bytes!("../db_migrations/000X_something.sql")),
     // ("000Y_another.sql", include_bytes!("../db_migrations/000Y_another.sql")),

--- a/src/whitenoise/error.rs
+++ b/src/whitenoise/error.rs
@@ -86,6 +86,9 @@ pub enum WhitenoiseError {
     #[error("nip04 direcet message error")]
     Nip04Error(#[from] nostr::nips::nip04::Error),
 
+    #[error("join error due to spawn blocking")]
+    JoinError(#[from] tokio::task::JoinError),
+
     #[error("Other error: {0}")]
     Other(#[from] anyhow::Error),
 }

--- a/src/whitenoise/event_processor.rs
+++ b/src/whitenoise/event_processor.rs
@@ -263,7 +263,7 @@ impl Whitenoise {
     ) -> Result<()> {
         // Process the welcome message - lock scope is minimal
         {
-            let nostr_mls = &*account.nostr_mls.lock().await;
+            let nostr_mls = &*account.nostr_mls.lock().unwrap();
             nostr_mls
                 .process_welcome(&event.id, &rumor)
                 .map_err(WhitenoiseError::NostrMlsError)?;
@@ -333,7 +333,7 @@ impl Whitenoise {
 
         let target_account = self.read_account_by_pubkey(&target_pubkey).await?;
 
-        let nostr_mls = &*target_account.nostr_mls.lock().await;
+        let nostr_mls = &*target_account.nostr_mls.lock().unwrap();
         match nostr_mls.process_message(&event) {
             Ok(result) => {
                 tracing::debug!(target: "whitenoise::event_processor::process_mls_message", "Processed MLS message - Result: {:?}", result);

--- a/src/whitenoise/mod.rs
+++ b/src/whitenoise/mod.rs
@@ -880,7 +880,7 @@ mod tests {
             let metadata = whitenoise.fetch_metadata_from(relays, pubkey).await;
             assert!(metadata.is_ok());
 
-            let contacts = whitenoise.fetch_contacts(&account).await;
+            let contacts = whitenoise.fetch_contacts(&account.pubkey).await;
             assert!(contacts.is_ok());
         }
 

--- a/src/whitenoise/mod.rs
+++ b/src/whitenoise/mod.rs
@@ -248,6 +248,13 @@ impl Whitenoise {
             *accounts = loaded_accounts;
         }
 
+        if whitenoise.nostr.client.relays().await.is_empty() {
+            // First time starting the app
+            for relay in Account::default_relays() {
+                whitenoise.nostr.client.add_relay(relay).await?;
+            }
+        }
+
         // No need to wait for all the relays to be up
         tokio::spawn({
             let client = whitenoise.nostr.client.clone();

--- a/src/whitenoise/mod.rs
+++ b/src/whitenoise/mod.rs
@@ -697,7 +697,7 @@ pub mod test_utils {
                 .nostr
                 .publish_event_builder_with_signer(
                     key_package_event_builder,
-                    &account.discovery_relays,
+                    &account.nip65_relays,
                     keys,
                 )
                 .await
@@ -874,7 +874,7 @@ mod tests {
 
             let account = account.unwrap();
 
-            let relays = account.discovery_relays.clone();
+            let relays = account.nip65_relays.clone();
 
             // Test all load methods return expected types (though they may be empty in test env)
             let metadata = whitenoise.fetch_metadata_from(relays, pubkey).await;

--- a/src/whitenoise/utils.rs
+++ b/src/whitenoise/utils.rs
@@ -105,7 +105,7 @@ impl Whitenoise {
                     .collect::<Vec<_>>()
             })
             .map_err(|e| sqlx::Error::ColumnDecode {
-                index: "discovery_relays".to_owned(),
+                index: "nip65_relays".to_owned(),
                 source: Box::new(e),
             })
     }


### PR DESCRIPTION
In this PR following tasks are completed.

1. @jgmontoya 's concern about migrations deleting existing user data fixed.
2. @erskingardner comment about having the ability to find mutual contacts
3. rename discovery_relays as nip65_relays for clarity
4. When the user tries to login with their existing nostr account, their preferred relay list is used