### PR TITLE
refactor(db_migrations): simplify migration

### DIFF
--- a/db_migrations/0004_accounts_relays.sql
+++ b/db_migrations/0004_accounts_relays.sql
@@ -1,30 +1,8 @@
--- Step 1: Create a new temporary table with the updated schema
-CREATE TABLE accounts_new (
-    pubkey TEXT PRIMARY KEY,
-    settings JSONB NOT NULL,
-    nip65_relays TEXT NOT NULL,
-    inbox_relays TEXT NOT NULL,
-    key_package_relays TEXT NOT NULL,
-    last_synced INTEGER NOT NULL
-);
+ALTER TABLE accounts
+  ADD COLUMN nip65_relays TEXT NOT NULL DEFAULT '[]';
+ALTER TABLE accounts
+  ADD COLUMN inbox_relays TEXT NOT NULL DEFAULT '[]';
+ALTER TABLE accounts
+  ADD COLUMN key_package_relays TEXT NOT NULL DEFAULT '[]';
 
--- Step 2: Copy data from old table to new table, with defaults for new columns
-INSERT INTO accounts_new (
-    pubkey, settings,
-    nip65_relays, inbox_relays, key_package_relays,
-    last_synced
-)
-SELECT
-    pubkey,
-    settings,
-    '[]',  -- default value for nip65_relays
-    '[]',  -- default value for inbox_relays
-    '[]',  -- default value for key_package_relays
-    last_synced
-FROM accounts;
-
--- Step 3: Drop the old table
-DROP TABLE accounts;
-
--- Step 4: Rename the new table to the original name
-ALTER TABLE accounts_new RENAME TO accounts;
+ALTER TABLE accounts DROP COLUMN onboarding;

--- a/src/whitenoise/database.rs
+++ b/src/whitenoise/database.rs
@@ -371,17 +371,17 @@ mod tests {
         assert_eq!(account_count.0, 1);
 
         // Verify the account data
-        let account: (String, String, String, String, String, i64) =
+        let account: (String, String, i64, String, String, String) =
             sqlx::query_as("SELECT * FROM accounts")
                 .fetch_one(&db2.pool)
                 .await
                 .expect("Failed to fetch account");
         assert_eq!(account.0, "test-pubkey");
         assert_eq!(account.1, "{}");
-        assert_eq!(account.2, "[1,2]");
-        assert_eq!(account.3, "[]");
-        assert_eq!(account.4, "[1]");
-        assert_eq!(account.5, 0);
+        assert_eq!(account.2, 0);
+        assert_eq!(account.3, "[1,2]");
+        assert_eq!(account.4, "[]");
+        assert_eq!(account.5, "[1]");
     }
 
     #[tokio::test]


### PR DESCRIPTION
Simplify Migration 0004 to directly alter the accounts table

Relates to https://github.com/parres-hq/whitenoise/issues/288