### PR TITLE
Fallback to default when contacts have no relays

### DIFF
--- a/src/whitenoise/accounts/contacts.rs
+++ b/src/whitenoise/accounts/contacts.rs
@@ -476,6 +476,24 @@ impl Whitenoise {
 
         Ok(())
     }
+
+    pub(crate) async fn temp_contact_with_defaults(&self, pubkey: PublicKey) -> Result<Contact> {
+        Ok(Contact {
+            pubkey,
+            metadata: None,
+            nip65_relays: Account::default_relays(),
+            inbox_relays: self
+                .relays_with_nip65_fallback(pubkey, Account::default_relays(), RelayType::Inbox)
+                .await?,
+            key_package_relays: self
+                .relays_with_nip65_fallback(
+                    pubkey,
+                    Account::default_relays(),
+                    RelayType::KeyPackage,
+                )
+                .await?,
+        })
+    }
 }
 
 #[cfg(test)]

--- a/src/whitenoise/accounts/groups.rs
+++ b/src/whitenoise/accounts/groups.rs
@@ -45,7 +45,13 @@ impl Whitenoise {
         let mut contacts = Vec::new();
 
         for pk in member_pubkeys.iter() {
-            let contact = self.load_contact(pk).await?;
+            let contact = match self.load_contact(pk).await {
+                Ok(contact) => contact,
+                Err(WhitenoiseError::ContactNotFound) => {
+                    self.temp_contact_with_defaults(*pk).await?
+                }
+                Err(e) => return Err(e),
+            };
             let relays_to_use = if contact.key_package_relays.is_empty() {
                 Account::default_relays()
             } else {
@@ -254,7 +260,13 @@ impl Whitenoise {
 
         // Fetch key packages for all members
         for pk in members.iter() {
-            let contact = self.load_contact(pk).await?;
+            let contact = match self.load_contact(pk).await {
+                Ok(contact) => contact,
+                Err(WhitenoiseError::ContactNotFound) => {
+                    self.temp_contact_with_defaults(*pk).await?
+                }
+                Err(e) => return Err(e),
+            };
             let relays_to_use = if contact.key_package_relays.is_empty() {
                 Account::default_relays()
             } else {

--- a/src/whitenoise/accounts/messages.rs
+++ b/src/whitenoise/accounts/messages.rs
@@ -259,11 +259,7 @@ impl Whitenoise {
 
         let _event_id = self
             .nostr
-            .publish_event_builder_with_signer(
-                dm_event_builder,
-                relays_to_use,
-                sender_keys,
-            )
+            .publish_event_builder_with_signer(dm_event_builder, relays_to_use, sender_keys)
             .await?;
 
         Ok(())

--- a/src/whitenoise/accounts/messages.rs
+++ b/src/whitenoise/accounts/messages.rs
@@ -251,11 +251,17 @@ impl Whitenoise {
             .tags(tags)
             .tag(Tag::public_key(*recepient_pubkey));
 
+        let relays_to_use = if contact.inbox_relays.is_empty() {
+            Account::default_relays()
+        } else {
+            contact.inbox_relays.clone()
+        };
+
         let _event_id = self
             .nostr
             .publish_event_builder_with_signer(
                 dm_event_builder,
-                contact.inbox_relays.clone(),
+                relays_to_use,
                 sender_keys,
             )
             .await?;

--- a/src/whitenoise/accounts/relays.rs
+++ b/src/whitenoise/accounts/relays.rs
@@ -305,6 +305,22 @@ impl Whitenoise {
 
         Ok(())
     }
+
+    pub(crate) async fn relays_with_nip65_fallback(
+        &self,
+        pubkey: PublicKey,
+        nip65_relays: DashSet<RelayUrl>,
+        relay_type: RelayType,
+    ) -> Result<DashSet<RelayUrl>> {
+        let relays = self
+            .fetch_relays_from(nip65_relays, pubkey, relay_type)
+            .await?;
+        if relays.is_empty() {
+            Ok(Account::default_relays())
+        } else {
+            Ok(relays)
+        }
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


* **Bug Fixes**
  * Improved reliability of direct message delivery by ensuring messages are sent using default relays when no inbox relays are specified for a contact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->