### PR TITLE
refactor(event_processor): extract event handlers to a module so they're reusable

### DIFF
--- a/src/whitenoise/event_processor/event_handlers/handle_giftwrap.rs
+++ b/src/whitenoise/event_processor/event_handlers/handle_giftwrap.rs
@@ -1,0 +1,183 @@
+use crate::whitenoise::accounts::Account;
+use crate::whitenoise::error::{Result, WhitenoiseError};
+use crate::whitenoise::Whitenoise;
+use nostr_sdk::prelude::*;
+
+impl Whitenoise {
+    pub async fn handle_giftwrap(&self, account: &Account, event: Event) -> Result<()> {
+        tracing::info!(
+            target: "whitenoise::event_handlers::handle_giftwrap",
+            "Giftwrap received for account: {} - processing not yet implemented",
+            account.pubkey.to_hex()
+        );
+
+        let keys = self
+            .secrets_store
+            .get_nostr_keys_for_pubkey(&account.pubkey)?;
+
+        let unwrapped = extract_rumor(&keys, &event).await.map_err(|e| {
+            WhitenoiseError::Configuration(format!("Failed to decrypt giftwrap: {}", e))
+        })?;
+
+        match unwrapped.rumor.kind {
+            Kind::MlsWelcome => {
+                self.process_welcome(account, event, unwrapped.rumor)
+                    .await?;
+            }
+            _ => {
+                tracing::debug!(
+                    target: "whitenoise::event_handlers::handle_giftwrap",
+                    "Received unhandled giftwrap of kind {:?}",
+                    unwrapped.rumor.kind
+                );
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn process_welcome(
+        &self,
+        account: &Account,
+        event: Event,
+        rumor: UnsignedEvent,
+    ) -> Result<()> {
+        // Process the welcome message - lock scope is minimal
+        {
+            let nostr_mls = &*account.nostr_mls.lock().unwrap();
+            nostr_mls
+                .process_welcome(&event.id, &rumor)
+                .map_err(WhitenoiseError::NostrMlsError)?;
+            tracing::debug!(target: "whitenoise::event_processor::process_welcome", "Processed welcome event");
+        } // nostr_mls lock released here
+
+        let key_package_event_id: Option<EventId> = rumor
+            .tags
+            .iter()
+            .find(|tag| {
+                tag.kind() == TagKind::SingleLetter(SingleLetterTag::lowercase(Alphabet::E))
+            })
+            .and_then(|tag| tag.content())
+            .and_then(|content| EventId::parse(content).ok());
+
+        if let Some(key_package_event_id) = key_package_event_id {
+            self.delete_key_package_from_relays_for_account(
+                account,
+                &key_package_event_id,
+                false, // For now we don't want to delete the key packages from MLS storage
+            )
+            .await?;
+            tracing::debug!(target: "whitenoise::event_processor::process_welcome", "Deleted used key package from relays");
+
+            self.publish_key_package_for_account(account).await?;
+            tracing::debug!(target: "whitenoise::event_processor::process_welcome", "Published new key package");
+        } else {
+            tracing::warn!(target: "whitenoise::event_processor::process_welcome", "No key package event id found in welcome event");
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::whitenoise::test_utils::*;
+
+    // Builds a real MLS Welcome rumor for `member_pubkey` by creating a group with `creator_account`
+    async fn build_welcome_giftwrap(
+        whitenoise: &Whitenoise,
+        creator_account: &Account,
+        member_pubkey: PublicKey,
+    ) -> Event {
+        // Fetch a real key package event for the member from relays
+        let key_pkg_event = whitenoise
+            .fetch_key_package_event_from(creator_account.key_package_relays.clone(), member_pubkey)
+            .await
+            .unwrap()
+            .expect("member must have a published key package");
+
+        // Create the group via nostr_mls directly to obtain welcome rumor
+        let (welcome_rumor, _unused_keys) = tokio::task::spawn_blocking({
+            let creator_account = creator_account.clone();
+            let key_pkg_event = key_pkg_event.clone();
+            move || -> core::result::Result<(UnsignedEvent, Keys), nostr_mls::error::Error> {
+                let nostr_mls = creator_account.nostr_mls.lock().unwrap();
+
+                let create_group_result = nostr_mls.create_group(
+                    &creator_account.pubkey,
+                    vec![key_pkg_event],
+                    vec![creator_account.pubkey],
+                    create_nostr_group_config_data(),
+                )?;
+
+                let rumor = create_group_result
+                    .welcome_rumors
+                    .first()
+                    .expect("welcome rumor exists")
+                    .clone();
+
+                // Return rumor plus a dummy Keys placeholder; will not be used outside
+                Ok((rumor, Keys::generate()))
+            }
+        })
+        .await
+        .unwrap()
+        .unwrap();
+
+        // Use the creator's real keys as signer to build the giftwrap
+        let creator_signer = whitenoise
+            .secrets_store
+            .get_nostr_keys_for_pubkey(&creator_account.pubkey)
+            .unwrap();
+
+        EventBuilder::gift_wrap(&creator_signer, &member_pubkey, welcome_rumor, vec![])
+            .await
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_handle_giftwrap_welcome_success() {
+        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+
+        // Create creator and one member account; setup publishes key packages and contacts
+        let creator_account = whitenoise.create_identity().await.unwrap();
+        let members = setup_multiple_test_accounts(&whitenoise, &creator_account, 1).await;
+        let member_account = members[0].0.clone();
+
+        // Build a real MLS Welcome giftwrap addressed to the member
+        let giftwrap_event =
+            build_welcome_giftwrap(&whitenoise, &creator_account, member_account.pubkey).await;
+
+        // Member should successfully process welcome
+        let result = whitenoise
+            .handle_giftwrap(&member_account, giftwrap_event)
+            .await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_handle_giftwrap_non_welcome_ok() {
+        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let account = whitenoise.create_identity().await.unwrap();
+
+        // Build a non-welcome rumor and giftwrap it to the account
+        let mut rumor = UnsignedEvent::new(
+            account.pubkey,
+            Timestamp::now(),
+            Kind::TextNote,
+            vec![],
+            "not a welcome".to_string(),
+        );
+        rumor.ensure_id();
+
+        // Any signer works; encryption targets receiver's pubkey
+        let sender_keys = create_test_keys();
+        let giftwrap_event = EventBuilder::gift_wrap(&sender_keys, &account.pubkey, rumor, vec![])
+            .await
+            .unwrap();
+
+        let result = whitenoise.handle_giftwrap(&account, giftwrap_event).await;
+        assert!(result.is_ok());
+    }
+}

--- a/src/whitenoise/event_processor/event_handlers/handle_mls_message.rs
+++ b/src/whitenoise/event_processor/event_handlers/handle_mls_message.rs
@@ -1,0 +1,166 @@
+use crate::whitenoise::accounts::Account;
+use crate::whitenoise::error::{Result, WhitenoiseError};
+use crate::whitenoise::Whitenoise;
+use nostr_sdk::prelude::*;
+
+impl Whitenoise {
+    pub async fn handle_mls_message(&self, account: &Account, event: Event) -> Result<()> {
+        tracing::debug!(
+          target: "whitenoise::event_handlers::handle_mls_message",
+          "Handling MLS message for account: {}",
+          account.pubkey.to_hex()
+        );
+
+        let nostr_mls = &*account.nostr_mls.lock().unwrap();
+        match nostr_mls.process_message(&event) {
+            Ok(result) => {
+                tracing::debug!(
+                  target: "whitenoise::event_handlers::handle_mls_message",
+                  "Handled MLS message - Result: {:?}",
+                  result
+                );
+                Ok(())
+            }
+            Err(e) => {
+                tracing::error!(
+                    target: "whitenoise::event_handlers::handle_mls_message",
+                    "MLS message handling failed for account {}: {}",
+                    account.pubkey.to_hex(),
+                    e
+                );
+                Err(WhitenoiseError::NostrMlsError(e))
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::whitenoise::test_utils::*;
+    use std::time::Duration;
+
+    #[tokio::test]
+    async fn test_handle_mls_message_success() {
+        // Arrange: Whitenoise and accounts
+        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let creator_account = whitenoise.create_identity().await.unwrap();
+        // Create one member account, set contact, publish key package
+        let members = setup_multiple_test_accounts(&whitenoise, &creator_account, 1).await;
+        let member_pubkey = members[0].0.pubkey;
+
+        // Give time for key package publish to propagate in test relays
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        // Create the group via high-level API
+        let _group = whitenoise
+            .create_group(
+                &creator_account,
+                vec![member_pubkey],
+                vec![creator_account.pubkey],
+                create_nostr_group_config_data(),
+            )
+            .await
+            .unwrap();
+
+        // Build a valid MLS group message event for the new group
+        let message_event = tokio::task::spawn_blocking({
+            let account = creator_account.clone();
+            move || -> core::result::Result<Event, nostr_mls::error::Error> {
+                let nostr_mls = account.nostr_mls.lock().unwrap();
+                let groups = nostr_mls.get_groups()?;
+                let group_id = groups
+                    .first()
+                    .expect("group must exist")
+                    .mls_group_id
+                    .clone();
+
+                let mut inner = UnsignedEvent::new(
+                    account.pubkey,
+                    Timestamp::now(),
+                    Kind::TextNote,
+                    vec![],
+                    "hello from test".to_string(),
+                );
+                inner.ensure_id();
+                let evt = nostr_mls.create_message(&group_id, inner)?;
+                Ok(evt)
+            }
+        })
+        .await
+        .unwrap()
+        .unwrap();
+
+        // Act
+        let result = whitenoise
+            .handle_mls_message(&creator_account, message_event)
+            .await;
+
+        // Assert
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_handle_mls_message_error_path() {
+        // Arrange: Whitenoise and accounts
+        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+        let creator_account = whitenoise.create_identity().await.unwrap();
+        let members = setup_multiple_test_accounts(&whitenoise, &creator_account, 1).await;
+        let member_pubkey = members[0].0.pubkey;
+        tokio::time::sleep(Duration::from_millis(300)).await;
+
+        // Create the group via high-level API
+        let _group = whitenoise
+            .create_group(
+                &creator_account,
+                vec![member_pubkey],
+                vec![creator_account.pubkey],
+                create_nostr_group_config_data(),
+            )
+            .await
+            .unwrap();
+
+        // Create a valid MLS message event for that group
+        let valid_event = tokio::task::spawn_blocking({
+            let account = creator_account.clone();
+            move || -> core::result::Result<Event, nostr_mls::error::Error> {
+                let nostr_mls = account.nostr_mls.lock().unwrap();
+                let groups = nostr_mls.get_groups()?;
+                let group_id = groups
+                    .first()
+                    .expect("group must exist")
+                    .mls_group_id
+                    .clone();
+                let mut inner = UnsignedEvent::new(
+                    account.pubkey,
+                    Timestamp::now(),
+                    Kind::TextNote,
+                    vec![],
+                    "msg".to_string(),
+                );
+                inner.ensure_id();
+                let evt = nostr_mls.create_message(&group_id, inner)?;
+                Ok(evt)
+            }
+        })
+        .await
+        .unwrap()
+        .unwrap();
+
+        // Corrupt it by changing the kind so MLS processing fails
+        let mut bad_event = valid_event.clone();
+        bad_event.kind = Kind::TextNote;
+
+        // Act
+        let result = whitenoise
+            .handle_mls_message(&creator_account, bad_event)
+            .await;
+
+        // Assert
+        assert!(result.is_err());
+        match result.err().unwrap() {
+            WhitenoiseError::NostrMlsError(_) => {}
+            other => panic!("Expected NostrMlsError, got: {:?}", other),
+        }
+    }
+}

--- a/src/whitenoise/event_processor/event_handlers/mod.rs
+++ b/src/whitenoise/event_processor/event_handlers/mod.rs
@@ -1,0 +1,2 @@
+mod handle_giftwrap;
+mod handle_mls_message;


### PR DESCRIPTION
Moves the event_processor from a single file to a dir, with the main logic in the mod.rs file.
Creates event_handlers folder within it to hold the core event processing logic. The idea is that these know nothing about subscriptions. This will allow us to reuse them on the initial background sync.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added support for processing gift-wrapped invitations, automatically handling MLS welcomes and publishing a fresh key package when joining groups.
  * Introduced dedicated handling of incoming MLS messages for more reliable delivery.

* Refactor
  * Switched to account-based routing with recipient validation to prevent misdirected giftwraps, improving security and traceability.

* Tests
  * Added tests for successful welcome handling and MLS message error paths to ensure robustness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->