### PR TITLE
Remove admins param from create_group, refactor tests a bit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2378,7 +2378,6 @@ checksum = "f0efe882e02d206d8d279c20eb40e03baf7cb5136a1476dc084a324fbc3ec42d"
 [[package]]
 name = "nostr"
 version = "0.43.0"
-source = "git+https://github.com/rust-nostr/nostr?rev=d70bed548d2e1399b758ad8bb7da9f058a716064#d70bed548d2e1399b758ad8bb7da9f058a716064"
 dependencies = [
  "aes",
  "base64 0.22.1",
@@ -2401,7 +2400,6 @@ dependencies = [
 [[package]]
 name = "nostr-blossom"
 version = "0.43.0"
-source = "git+https://github.com/rust-nostr/nostr?rev=d70bed548d2e1399b758ad8bb7da9f058a716064#d70bed548d2e1399b758ad8bb7da9f058a716064"
 dependencies = [
  "base64 0.22.1",
  "nostr",
@@ -2412,7 +2410,6 @@ dependencies = [
 [[package]]
 name = "nostr-database"
 version = "0.43.0"
-source = "git+https://github.com/rust-nostr/nostr?rev=d70bed548d2e1399b758ad8bb7da9f058a716064#d70bed548d2e1399b758ad8bb7da9f058a716064"
 dependencies = [
  "flatbuffers",
  "lru",
@@ -2423,7 +2420,6 @@ dependencies = [
 [[package]]
 name = "nostr-lmdb"
 version = "0.43.0"
-source = "git+https://github.com/rust-nostr/nostr?rev=d70bed548d2e1399b758ad8bb7da9f058a716064#d70bed548d2e1399b758ad8bb7da9f058a716064"
 dependencies = [
  "async-utility",
  "flume",
@@ -2437,7 +2433,6 @@ dependencies = [
 [[package]]
 name = "nostr-mls"
 version = "0.43.0"
-source = "git+https://github.com/rust-nostr/nostr?rev=d70bed548d2e1399b758ad8bb7da9f058a716064#d70bed548d2e1399b758ad8bb7da9f058a716064"
 dependencies = [
  "aes-gcm",
  "nostr",
@@ -2453,7 +2448,6 @@ dependencies = [
 [[package]]
 name = "nostr-mls-sqlite-storage"
 version = "0.43.0"
-source = "git+https://github.com/rust-nostr/nostr?rev=d70bed548d2e1399b758ad8bb7da9f058a716064#d70bed548d2e1399b758ad8bb7da9f058a716064"
 dependencies = [
  "nostr",
  "nostr-mls-storage",
@@ -2469,7 +2463,6 @@ dependencies = [
 [[package]]
 name = "nostr-mls-storage"
 version = "0.43.0"
-source = "git+https://github.com/rust-nostr/nostr?rev=d70bed548d2e1399b758ad8bb7da9f058a716064#d70bed548d2e1399b758ad8bb7da9f058a716064"
 dependencies = [
  "nostr",
  "openmls",
@@ -2481,7 +2474,6 @@ dependencies = [
 [[package]]
 name = "nostr-relay-pool"
 version = "0.43.0"
-source = "git+https://github.com/rust-nostr/nostr?rev=d70bed548d2e1399b758ad8bb7da9f058a716064#d70bed548d2e1399b758ad8bb7da9f058a716064"
 dependencies = [
  "async-utility",
  "async-wsocket",
@@ -2497,7 +2489,6 @@ dependencies = [
 [[package]]
 name = "nostr-sdk"
 version = "0.43.0"
-source = "git+https://github.com/rust-nostr/nostr?rev=d70bed548d2e1399b758ad8bb7da9f058a716064#d70bed548d2e1399b758ad8bb7da9f058a716064"
 dependencies = [
  "async-utility",
  "nostr",
@@ -2583,7 +2574,6 @@ dependencies = [
 [[package]]
 name = "nwc"
 version = "0.43.0"
-source = "git+https://github.com/rust-nostr/nostr?rev=d70bed548d2e1399b758ad8bb7da9f058a716064#d70bed548d2e1399b758ad8bb7da9f058a716064"
 dependencies = [
  "async-utility",
  "nostr",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2378,6 +2378,7 @@ checksum = "f0efe882e02d206d8d279c20eb40e03baf7cb5136a1476dc084a324fbc3ec42d"
 [[package]]
 name = "nostr"
 version = "0.43.0"
+source = "git+https://github.com/erskingardner/rust-nostr?rev=03934fc8e1e1e6c831f282cde9e13589be15c21e#03934fc8e1e1e6c831f282cde9e13589be15c21e"
 dependencies = [
  "aes",
  "base64 0.22.1",
@@ -2400,6 +2401,7 @@ dependencies = [
 [[package]]
 name = "nostr-blossom"
 version = "0.43.0"
+source = "git+https://github.com/erskingardner/rust-nostr?rev=03934fc8e1e1e6c831f282cde9e13589be15c21e#03934fc8e1e1e6c831f282cde9e13589be15c21e"
 dependencies = [
  "base64 0.22.1",
  "nostr",
@@ -2410,6 +2412,7 @@ dependencies = [
 [[package]]
 name = "nostr-database"
 version = "0.43.0"
+source = "git+https://github.com/erskingardner/rust-nostr?rev=03934fc8e1e1e6c831f282cde9e13589be15c21e#03934fc8e1e1e6c831f282cde9e13589be15c21e"
 dependencies = [
  "flatbuffers",
  "lru",
@@ -2420,6 +2423,7 @@ dependencies = [
 [[package]]
 name = "nostr-lmdb"
 version = "0.43.0"
+source = "git+https://github.com/erskingardner/rust-nostr?rev=03934fc8e1e1e6c831f282cde9e13589be15c21e#03934fc8e1e1e6c831f282cde9e13589be15c21e"
 dependencies = [
  "async-utility",
  "flume",
@@ -2433,6 +2437,7 @@ dependencies = [
 [[package]]
 name = "nostr-mls"
 version = "0.43.0"
+source = "git+https://github.com/erskingardner/rust-nostr?rev=03934fc8e1e1e6c831f282cde9e13589be15c21e#03934fc8e1e1e6c831f282cde9e13589be15c21e"
 dependencies = [
  "aes-gcm",
  "nostr",
@@ -2448,6 +2453,7 @@ dependencies = [
 [[package]]
 name = "nostr-mls-sqlite-storage"
 version = "0.43.0"
+source = "git+https://github.com/erskingardner/rust-nostr?rev=03934fc8e1e1e6c831f282cde9e13589be15c21e#03934fc8e1e1e6c831f282cde9e13589be15c21e"
 dependencies = [
  "nostr",
  "nostr-mls-storage",
@@ -2463,6 +2469,7 @@ dependencies = [
 [[package]]
 name = "nostr-mls-storage"
 version = "0.43.0"
+source = "git+https://github.com/erskingardner/rust-nostr?rev=03934fc8e1e1e6c831f282cde9e13589be15c21e#03934fc8e1e1e6c831f282cde9e13589be15c21e"
 dependencies = [
  "nostr",
  "openmls",
@@ -2474,6 +2481,7 @@ dependencies = [
 [[package]]
 name = "nostr-relay-pool"
 version = "0.43.0"
+source = "git+https://github.com/erskingardner/rust-nostr?rev=03934fc8e1e1e6c831f282cde9e13589be15c21e#03934fc8e1e1e6c831f282cde9e13589be15c21e"
 dependencies = [
  "async-utility",
  "async-wsocket",
@@ -2489,6 +2497,7 @@ dependencies = [
 [[package]]
 name = "nostr-sdk"
 version = "0.43.0"
+source = "git+https://github.com/erskingardner/rust-nostr?rev=03934fc8e1e1e6c831f282cde9e13589be15c21e#03934fc8e1e1e6c831f282cde9e13589be15c21e"
 dependencies = [
  "async-utility",
  "nostr",
@@ -2574,6 +2583,7 @@ dependencies = [
 [[package]]
 name = "nwc"
 version = "0.43.0"
+source = "git+https://github.com/erskingardner/rust-nostr?rev=03934fc8e1e1e6c831f282cde9e13589be15c21e#03934fc8e1e1e6c831f282cde9e13589be15c21e"
 dependencies = [
  "async-utility",
  "nostr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,32 +28,32 @@ keyring = { version = "3.6", features = [
 ] }
 lightning-invoice = "0.33.1"
 
-# nostr = { version = "0.43.0", git="https://github.com/rust-nostr/nostr", rev = "d70bed548d2e1399b758ad8bb7da9f058a716064", features = [ "std" ] }
-# nostr-mls = { version = "0.43.0", git="https://github.com/rust-nostr/nostr", rev = "d70bed548d2e1399b758ad8bb7da9f058a716064" }
-# nostr-mls-sqlite-storage = { version = "0.43.0", git="https://github.com/rust-nostr/nostr", rev = "d70bed548d2e1399b758ad8bb7da9f058a716064" }
-# nwc = { version = "0.43.0", git="https://github.com/rust-nostr/nostr", rev = "d70bed548d2e1399b758ad8bb7da9f058a716064" }
-# nostr-blossom = { version = "0.43.0", git="https://github.com/rust-nostr/nostr", rev = "d70bed548d2e1399b758ad8bb7da9f058a716064" }
-# nostr-sdk = { version = "0.43.0", git="https://github.com/rust-nostr/nostr", rev = "d70bed548d2e1399b758ad8bb7da9f058a716064", features = [
-#     "lmdb",
-#     "nip04",
-#     "nip44",
-#     "nip47",
-#     "nip59",
-# ] }
-
-# LOCAL RUST_NOSTR FOR DEVELOPMENT
-nostr = { version = "0.43", path="../rust-nostr/crates/nostr", features = [ "std" ] }
-nostr-mls = { version = "0.43", path="../rust-nostr/mls/nostr-mls" }
-nostr-mls-sqlite-storage = { version = "0.43", path="../rust-nostr/mls/nostr-mls-sqlite-storage" }
-nwc = { version = "0.43", path="../rust-nostr/crates/nwc" }
-nostr-blossom = { version = "0.43", path="../rust-nostr/rfs/nostr-blossom" }
-nostr-sdk = { version = "0.43", path="../rust-nostr/crates/nostr-sdk", features = [
+nostr = { version = "0.43.0", git="https://github.com/erskingardner/rust-nostr", rev = "03934fc8e1e1e6c831f282cde9e13589be15c21e", features = [ "std" ] }
+nostr-mls = { version = "0.43.0", git="https://github.com/erskingardner/rust-nostr", rev = "03934fc8e1e1e6c831f282cde9e13589be15c21e" }
+nostr-mls-sqlite-storage = { version = "0.43.0", git="https://github.com/erskingardner/rust-nostr", rev = "03934fc8e1e1e6c831f282cde9e13589be15c21e" }
+nwc = { version = "0.43.0", git="https://github.com/erskingardner/rust-nostr", rev = "03934fc8e1e1e6c831f282cde9e13589be15c21e" }
+nostr-blossom = { version = "0.43.0", git="https://github.com/erskingardner/rust-nostr", rev = "03934fc8e1e1e6c831f282cde9e13589be15c21e" }
+nostr-sdk = { version = "0.43.0", git="https://github.com/erskingardner/rust-nostr", rev = "03934fc8e1e1e6c831f282cde9e13589be15c21e", features = [
     "lmdb",
     "nip04",
     "nip44",
     "nip47",
     "nip59",
 ] }
+
+# LOCAL RUST_NOSTR FOR DEVELOPMENT
+# nostr = { version = "0.43", path="../rust-nostr/crates/nostr", features = [ "std" ] }
+# nostr-mls = { version = "0.43", path="../rust-nostr/mls/nostr-mls" }
+# nostr-mls-sqlite-storage = { version = "0.43", path="../rust-nostr/mls/nostr-mls-sqlite-storage" }
+# nwc = { version = "0.43", path="../rust-nostr/crates/nwc" }
+# nostr-blossom = { version = "0.43", path="../rust-nostr/rfs/nostr-blossom" }
+# nostr-sdk = { version = "0.43", path="../rust-nostr/crates/nostr-sdk", features = [
+#     "lmdb",
+#     "nip04",
+#     "nip44",
+#     "nip47",
+#     "nip59",
+# ] }
 
 petname = "2.0.2"
 rand = "0.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,31 +28,32 @@ keyring = { version = "3.6", features = [
 ] }
 lightning-invoice = "0.33.1"
 
-nostr = { version = "0.43.0", git="https://github.com/rust-nostr/nostr", rev = "d70bed548d2e1399b758ad8bb7da9f058a716064", features = [ "std" ] }
-nostr-mls = { version = "0.43.0", git="https://github.com/rust-nostr/nostr", rev = "d70bed548d2e1399b758ad8bb7da9f058a716064" }
-nostr-mls-sqlite-storage = { version = "0.43.0", git="https://github.com/rust-nostr/nostr", rev = "d70bed548d2e1399b758ad8bb7da9f058a716064" }
-nwc = { version = "0.43.0", git="https://github.com/rust-nostr/nostr", rev = "d70bed548d2e1399b758ad8bb7da9f058a716064" }
-nostr-blossom = { version = "0.43.0", git="https://github.com/rust-nostr/nostr", rev = "d70bed548d2e1399b758ad8bb7da9f058a716064" }
-nostr-sdk = { version = "0.43.0", git="https://github.com/rust-nostr/nostr", rev = "d70bed548d2e1399b758ad8bb7da9f058a716064", features = [
-    "lmdb",
-    "nip04",
-    "nip44",
-    "nip47",
-    "nip59",
-] }
-
-# LOCAL RUST_NOSTR FOR DEVELOPMENT
-# nostr = { version = "0.43", path="../rust-nostr/crates/nostr", features = [ "std" ] }
-# nostr-mls = { version = "0.43", path="../rust-nostr/mls/nostr-mls" }
-# nostr-mls-sqlite-storage = { version = "0.43", path="../rust-nostr/mls/nostr-mls-sqlite-storage" }
-# nostr-sdk = { version = "0.43", path="../rust-nostr/crates/nostr-sdk", features = [
+# nostr = { version = "0.43.0", git="https://github.com/rust-nostr/nostr", rev = "d70bed548d2e1399b758ad8bb7da9f058a716064", features = [ "std" ] }
+# nostr-mls = { version = "0.43.0", git="https://github.com/rust-nostr/nostr", rev = "d70bed548d2e1399b758ad8bb7da9f058a716064" }
+# nostr-mls-sqlite-storage = { version = "0.43.0", git="https://github.com/rust-nostr/nostr", rev = "d70bed548d2e1399b758ad8bb7da9f058a716064" }
+# nwc = { version = "0.43.0", git="https://github.com/rust-nostr/nostr", rev = "d70bed548d2e1399b758ad8bb7da9f058a716064" }
+# nostr-blossom = { version = "0.43.0", git="https://github.com/rust-nostr/nostr", rev = "d70bed548d2e1399b758ad8bb7da9f058a716064" }
+# nostr-sdk = { version = "0.43.0", git="https://github.com/rust-nostr/nostr", rev = "d70bed548d2e1399b758ad8bb7da9f058a716064", features = [
 #     "lmdb",
 #     "nip04",
 #     "nip44",
 #     "nip47",
 #     "nip59",
 # ] }
-# nwc = { version = "0.43", path="../rust-nostr/crates/nwc" }
+
+# LOCAL RUST_NOSTR FOR DEVELOPMENT
+nostr = { version = "0.43", path="../rust-nostr/crates/nostr", features = [ "std" ] }
+nostr-mls = { version = "0.43", path="../rust-nostr/mls/nostr-mls" }
+nostr-mls-sqlite-storage = { version = "0.43", path="../rust-nostr/mls/nostr-mls-sqlite-storage" }
+nwc = { version = "0.43", path="../rust-nostr/crates/nwc" }
+nostr-blossom = { version = "0.43", path="../rust-nostr/rfs/nostr-blossom" }
+nostr-sdk = { version = "0.43", path="../rust-nostr/crates/nostr-sdk", features = [
+    "lmdb",
+    "nip04",
+    "nip44",
+    "nip47",
+    "nip59",
+] }
 
 petname = "2.0.2"
 rand = "0.9"

--- a/src/integration_tests/test_cases/shared/create_group.rs
+++ b/src/integration_tests/test_cases/shared/create_group.rs
@@ -43,19 +43,20 @@ impl TestCase for CreateGroupTestCase {
             .iter()
             .map(|name| context.get_account(name).map(|acc| acc.pubkey))
             .collect::<Result<Vec<_>, _>>()?;
+        let admin_pubkeys = vec![creator.pubkey];
 
         let test_group = context
             .whitenoise
             .create_group(
                 creator,
                 member_pubkeys,
-                vec![creator.pubkey],
                 NostrGroupConfigData::new(
                     self.group_name.clone(),
                     self.group_description.clone(),
-                    None,
-                    None,
+                    None, // image_url
+                    None, // image_key
                     vec![RelayUrl::parse("ws://localhost:8080").unwrap()],
+                    admin_pubkeys,
                 ),
                 None,
             )

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ pub use types::MessageWithTokens;
 pub use whitenoise::accounts::Account;
 pub use whitenoise::app_settings::{AppSettings, ThemeMode};
 pub use whitenoise::error::WhitenoiseError;
+pub use whitenoise::group_information::{GroupInformation, GroupType};
 pub use whitenoise::message_aggregator::{
     ChatMessage, EmojiReaction, ReactionSummary, UserReaction,
 };
@@ -61,7 +62,7 @@ pub use nostr::Tags;
 
 // Nostr MLS Types
 /// Nostr MLS Group. Re-exported from [`nostr_mls::group_types::Group`](https://docs.rs/nostr-mls/latest/nostr_mls/group_types/struct.Group.html)
-pub use nostr_mls::prelude::group_types::{Group, GroupState, GroupType};
+pub use nostr_mls::prelude::group_types::{Group, GroupState};
 
 /// Nostr MLS Group ID. Re-exported from [`open_mls::group::GroupId`](https://latest.openmls.tech/doc/openmls/group/struct.GroupId.html)
 pub use nostr_mls::prelude::GroupId;

--- a/src/whitenoise/event_processor/event_handlers/handle_giftwrap.rs
+++ b/src/whitenoise/event_processor/event_handlers/handle_giftwrap.rs
@@ -114,8 +114,7 @@ mod tests {
             .create_group(
                 &creator_account.pubkey,
                 vec![key_pkg_event],
-                vec![creator_account.pubkey],
-                create_nostr_group_config_data(),
+                create_nostr_group_config_data(vec![creator_account.pubkey]),
             )
             .unwrap();
 

--- a/src/whitenoise/event_processor/event_handlers/handle_mls_message.rs
+++ b/src/whitenoise/event_processor/event_handlers/handle_mls_message.rs
@@ -60,8 +60,7 @@ mod tests {
             .create_group(
                 &creator_account,
                 vec![member_pubkey],
-                vec![creator_account.pubkey],
-                create_nostr_group_config_data(),
+                create_nostr_group_config_data(vec![creator_account.pubkey]),
                 None,
             )
             .await
@@ -110,8 +109,7 @@ mod tests {
             .create_group(
                 &creator_account,
                 vec![member_pubkey],
-                vec![creator_account.pubkey],
-                create_nostr_group_config_data(),
+                create_nostr_group_config_data(vec![creator_account.pubkey]),
                 None,
             )
             .await

--- a/src/whitenoise/groups.rs
+++ b/src/whitenoise/groups.rs
@@ -19,14 +19,12 @@ impl Whitenoise {
     /// # Arguments
     /// * `creator_account` - Account of the group creator (must be the active account)
     /// * `member_pubkeys` - List of public keys for group members
-    /// * `admin_pubkeys` - List of public keys for group admins
     /// * `config` - Group configuration data
     /// * `group_type` - Optional explicit group type. If None, will be inferred from participant count
     pub async fn create_group(
         &self,
         creator_account: &Account,
         member_pubkeys: Vec<PublicKey>,
-        admin_pubkeys: Vec<PublicKey>,
         config: NostrGroupConfigData,
         group_type: Option<GroupType>,
     ) -> Result<group_types::Group> {
@@ -68,8 +66,7 @@ impl Whitenoise {
         let create_group_result = nostr_mls.create_group(
             &creator_account.pubkey,
             key_package_events.clone(),
-            admin_pubkeys,
-            config,
+            config
         )?;
 
         let group_ids = nostr_mls
@@ -311,7 +308,7 @@ impl Whitenoise {
             // Create a timestamp 1 month in the future
             let one_month_future = Timestamp::now() + Duration::from_secs(30 * 24 * 60 * 60);
 
-            // Use fallback relays if contact has no inbox relays configured
+            //  TODO: Maybe need to use fallback relays if contact has no inbox relays configured
             let relays_to_use = user.relays(RelayType::Inbox, &self.database).await?;
 
             self.nostr
@@ -364,6 +361,36 @@ impl Whitenoise {
             .await?;
         Ok(())
     }
+
+    /// Updates group metadata and publishes the change to group relays.
+    ///
+    /// This method updates the group data and publishes the change to group relays.
+    ///
+    /// # Arguments
+    /// * `account` - The account performing the group data update (must be group admin)
+    /// * `group_id` - The ID of the group to update
+    /// * `group_data` - The new group data to update
+    pub async fn update_group_data(&self, account: &Account, group_id: &GroupId, group_data: NostrGroupDataUpdate) -> Result<()> {
+        let nostr_mls = Account::create_nostr_mls(account.pubkey, &self.config.data_dir)?;
+        let update_result = nostr_mls.update_group_data(group_id, group_data)?;
+        nostr_mls.merge_pending_commit(group_id)?;
+        let group_relays = nostr_mls.get_relays(group_id)?;
+
+        let evolution_event = update_result.evolution_event;
+
+        let mut relays = HashSet::new();
+        for relay_url in group_relays {
+            let db_relay = self.find_or_create_relay_by_url(&relay_url).await?;
+            relays.insert(db_relay);
+        }
+
+        self.nostr
+            .publish_event_to(evolution_event, &relays.into_iter().collect::<Vec<_>>())
+            .await?;
+        Ok(())
+    }
+
+
 }
 
 #[cfg(test)]
@@ -440,14 +467,13 @@ mod tests {
         member_pubkeys: Vec<PublicKey>,
         admin_pubkeys: Vec<PublicKey>,
     ) {
-        let config = create_nostr_group_config_data();
+        let config = create_nostr_group_config_data(admin_pubkeys.clone());
         // Create the group
         let result = whitenoise
             .create_group(
                 creator_account,
                 member_pubkeys.clone(),
-                admin_pubkeys.clone(),
-                create_nostr_group_config_data(),
+                config.clone(),
                 None,
             )
             .await;
@@ -455,11 +481,24 @@ mod tests {
         // Assert the group was created successfully
         assert!(result.is_ok(), "Error {:?}", result.unwrap_err());
         let group = result.unwrap();
+
+        // Verify group metadata matches configuration
         assert_eq!(group.name, config.name);
         assert_eq!(group.description, config.description);
-        assert!(group.admin_pubkeys.contains(&creator_account.pubkey));
-        assert!(group.admin_pubkeys.contains(&member_pubkeys[0]));
+        assert_eq!(group.image_url, config.image_url);
+        assert_eq!(group.image_key, config.image_key);
 
+        // Verify admin configuration
+        assert_eq!(group.admin_pubkeys.len(), admin_pubkeys.len());
+        for admin_pk in &admin_pubkeys {
+            assert!(group.admin_pubkeys.contains(admin_pk),
+                "Admin {} not found in group.admin_pubkeys", admin_pk);
+        }
+
+        // Verify group state and type
+        // Just check that group is in a valid state (we can't verify exact state without knowing the enum path)
+
+        // Verify group information was created properly
         let group_info = GroupInformation::get_by_mls_group_id(&group.mls_group_id, whitenoise)
             .await
             .unwrap();
@@ -468,6 +507,22 @@ mod tests {
             group_info.group_type,
             crate::whitenoise::group_information::GroupType::Group
         );
+        // Note: participant_count is stored separately and managed by the GroupInformation logic
+
+        // Verify group members can be retrieved
+        let members = whitenoise.group_members(creator_account, &group.mls_group_id).await.unwrap();
+        assert_eq!(members.len(), member_pubkeys.len() + 1); // +1 for creator
+        assert!(members.contains(&creator_account.pubkey), "Creator not in member list");
+        for member_pk in &member_pubkeys {
+            assert!(members.contains(member_pk), "Member {} not found in group", member_pk);
+        }
+
+        // Verify group admins can be retrieved
+        let admins = whitenoise.group_admins(creator_account, &group.mls_group_id).await.unwrap();
+        assert_eq!(admins.len(), admin_pubkeys.len());
+        for admin_pk in &admin_pubkeys {
+            assert!(admins.contains(admin_pk), "Admin {} not found in admin list", admin_pk);
+        }
     }
 
     /// Test case: Member/admin validation fails - empty admin list
@@ -477,12 +532,12 @@ mod tests {
         member_pubkeys: Vec<PublicKey>,
         admin_pubkeys: Vec<PublicKey>,
     ) {
+        let config = create_nostr_group_config_data(admin_pubkeys.clone());
         let result = whitenoise
             .create_group(
                 creator_account,
                 member_pubkeys,
-                admin_pubkeys,
-                create_nostr_group_config_data(),
+                config.clone(),
                 None,
             )
             .await;
@@ -507,12 +562,12 @@ mod tests {
         member_pubkeys: Vec<PublicKey>,
         admin_pubkeys: Vec<PublicKey>,
     ) {
+        let config = create_nostr_group_config_data(admin_pubkeys);
         let result = whitenoise
             .create_group(
                 creator_account,
                 member_pubkeys,
-                admin_pubkeys,
-                create_nostr_group_config_data(),
+                config,
                 None,
             )
             .await;
@@ -528,12 +583,12 @@ mod tests {
         member_pubkeys: Vec<PublicKey>,
         admin_pubkeys: Vec<PublicKey>,
     ) {
+        let config = create_nostr_group_config_data(admin_pubkeys);
         let result = whitenoise
             .create_group(
                 creator_account,
                 member_pubkeys,
-                admin_pubkeys,
-                create_nostr_group_config_data(),
+                config,
                 None,
             )
             .await;
@@ -558,12 +613,16 @@ mod tests {
         member_pubkeys: Vec<PublicKey>,
         admin_pubkeys: Vec<PublicKey>,
     ) {
+        // Direct message group should have exactly 1 member (plus creator = 2 total)
+        assert_eq!(member_pubkeys.len(), 1, "Direct message group should have exactly 1 member");
+        assert_eq!(admin_pubkeys.len(), 2, "Direct message group should have 2 admins (both participants)");
+
+        let config = create_nostr_group_config_data(admin_pubkeys.clone());
         let result = whitenoise
             .create_group(
                 creator_account,
                 member_pubkeys.clone(),
-                admin_pubkeys.clone(),
-                create_nostr_group_config_data(),
+                config,
                 None,
             )
             .await;
@@ -571,6 +630,7 @@ mod tests {
         assert!(result.is_ok(), "Error {:?}", result.unwrap_err());
         let group = result.unwrap();
 
+        // Verify it's automatically classified as DirectMessage type
         let group_info = GroupInformation::get_by_mls_group_id(&group.mls_group_id, whitenoise)
             .await
             .unwrap();
@@ -579,5 +639,144 @@ mod tests {
             group_info.group_type,
             crate::whitenoise::group_information::GroupType::DirectMessage
         );
+        // DirectMessage groups should have exactly 2 participants (verified via member count below)
+
+        // Verify both participants are admins (standard for DM groups)
+        let admins = whitenoise.group_admins(creator_account, &group.mls_group_id).await.unwrap();
+        assert_eq!(admins.len(), 2, "DirectMessage group should have 2 admins");
+        assert!(admins.contains(&creator_account.pubkey), "Creator should be admin");
+        assert!(admins.contains(&member_pubkeys[0]), "Member should be admin");
+
+        // Verify membership
+        let members = whitenoise.group_members(creator_account, &group.mls_group_id).await.unwrap();
+        assert_eq!(members.len(), 2, "DirectMessage group should have exactly 2 members");
+        assert!(members.contains(&creator_account.pubkey), "Creator should be member");
+        assert!(members.contains(&member_pubkeys[0]), "Member should be member");
+    }
+
+    #[tokio::test]
+    async fn test_group_member_management() {
+        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+
+        // Setup creator and initial members
+        let creator_account = whitenoise.create_identity().await.unwrap();
+        let initial_members = setup_multiple_test_accounts(&whitenoise, 2).await;
+        let initial_member_pubkeys = initial_members.iter().map(|(acc, _)| acc.pubkey).collect::<Vec<_>>();
+
+        // Create group with initial members
+        let admin_pubkeys = vec![creator_account.pubkey];
+        let config = create_nostr_group_config_data(admin_pubkeys.clone());
+        let group = whitenoise
+            .create_group(&creator_account, initial_member_pubkeys.clone(), config, None)
+            .await
+            .unwrap();
+
+        // Verify initial membership
+        let members = whitenoise.group_members(&creator_account, &group.mls_group_id).await.unwrap();
+        assert_eq!(members.len(), 3); // creator + 2 initial members
+
+        // Add new members
+        let new_members = setup_multiple_test_accounts(&whitenoise, 2).await;
+        let new_member_pubkeys = new_members.iter().map(|(acc, _)| acc.pubkey).collect::<Vec<_>>();
+
+        let add_result = whitenoise
+            .add_members_to_group(&creator_account, &group.mls_group_id, new_member_pubkeys.clone())
+            .await;
+        assert!(add_result.is_ok(), "Failed to add members: {:?}", add_result.unwrap_err());
+
+        // Verify new membership count
+        let updated_members = whitenoise.group_members(&creator_account, &group.mls_group_id).await.unwrap();
+        assert_eq!(updated_members.len(), 5); // creator + 2 initial + 2 new
+        for new_member_pk in &new_member_pubkeys {
+            assert!(updated_members.contains(new_member_pk), "New member {} not found", new_member_pk);
+        }
+
+        // Remove one member
+        let member_to_remove = vec![initial_member_pubkeys[0]];
+        let remove_result = whitenoise
+            .remove_members_from_group(&creator_account, &group.mls_group_id, member_to_remove.clone())
+            .await;
+        assert!(remove_result.is_ok(), "Failed to remove member: {:?}", remove_result.unwrap_err());
+
+        // Verify final membership
+        let final_members = whitenoise.group_members(&creator_account, &group.mls_group_id).await.unwrap();
+        assert_eq!(final_members.len(), 4); // creator + 1 remaining initial + 2 new
+        assert!(!final_members.contains(&member_to_remove[0]), "Removed member still in group");
+    }
+
+    #[tokio::test]
+    async fn test_update_group_data() {
+        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+
+        // Setup creator and member
+        let creator_account = whitenoise.create_identity().await.unwrap();
+        let members = setup_multiple_test_accounts(&whitenoise, 1).await;
+        let member_pubkeys = vec![members[0].0.pubkey];
+
+        // Create group
+        let admin_pubkeys = vec![creator_account.pubkey];
+        let config = create_nostr_group_config_data(admin_pubkeys.clone());
+        let group = whitenoise
+            .create_group(&creator_account, member_pubkeys, config, None)
+            .await
+            .unwrap();
+
+        // Update group data
+        let new_group_data = nostr_mls::groups::NostrGroupDataUpdate {
+            name: Some("Updated Group Name".to_string()),
+            description: Some("Updated description".to_string()),
+            image_url: Some(Some("https://example.com/new_image.png".to_string())),
+            image_key: Some(Some(b"new image key".to_vec())),
+            admins: None,
+            relays: None,
+        };
+
+        let update_result = whitenoise
+            .update_group_data(&creator_account, &group.mls_group_id, new_group_data.clone())
+            .await;
+        assert!(update_result.is_ok(), "Failed to update group data: {:?}", update_result.unwrap_err());
+
+        // Verify the group data was updated
+        let updated_groups = whitenoise.groups(&creator_account, true).await.unwrap();
+        let updated_group = updated_groups
+            .iter()
+            .find(|g| g.mls_group_id == group.mls_group_id)
+            .expect("Updated group not found");
+
+        assert_eq!(updated_group.name, new_group_data.name.unwrap());
+        assert_eq!(updated_group.description, new_group_data.description.unwrap());
+        assert_eq!(updated_group.image_url, new_group_data.image_url.unwrap());
+        assert_eq!(updated_group.image_key, new_group_data.image_key.unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_groups_filtering() {
+        let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
+
+        // Setup accounts
+        let creator_account = whitenoise.create_identity().await.unwrap();
+        let members = setup_multiple_test_accounts(&whitenoise, 1).await;
+        let member_pubkeys = vec![members[0].0.pubkey];
+
+        // Create a group
+        let admin_pubkeys = vec![creator_account.pubkey];
+        let config = create_nostr_group_config_data(admin_pubkeys);
+        let _group = whitenoise
+            .create_group(&creator_account, member_pubkeys, config, None)
+            .await
+            .unwrap();
+
+        // Test getting all groups
+        let all_groups = whitenoise.groups(&creator_account, false).await.unwrap();
+        assert!(!all_groups.is_empty(), "Should have at least one group");
+
+        // Test getting only active groups
+        let active_groups = whitenoise.groups(&creator_account, true).await.unwrap();
+        assert!(!active_groups.is_empty(), "Should have at least one active group");
+
+        // All groups should be active in this test case
+        assert_eq!(all_groups.len(), active_groups.len(), "All groups should be active");
+
+        // All groups should be in a valid state (exact verification depends on state enum implementation)
     }
 }

--- a/src/whitenoise/mod.rs
+++ b/src/whitenoise/mod.rs
@@ -518,13 +518,14 @@ pub mod test_utils {
         (account, keys)
     }
 
-    pub(crate) fn create_nostr_group_config_data() -> NostrGroupConfigData {
+    pub(crate) fn create_nostr_group_config_data(admins: Vec<PublicKey>) -> NostrGroupConfigData {
         NostrGroupConfigData {
             name: "Test group".to_owned(),
             description: "test description".to_owned(),
             image_url: Some("http://test_blossom:53232/fake_img.png".to_owned()),
             image_key: Some(b"fake key to encrypt image".to_vec()),
             relays: vec![RelayUrl::parse("ws://localhost:8080/").unwrap()],
+            admins,
         }
     }
 

--- a/src/whitenoise/welcomes.rs
+++ b/src/whitenoise/welcomes.rs
@@ -173,13 +173,12 @@ mod tests {
 
         // Setup admin accounts (creator + one member as admin)
         let admin_pubkeys = vec![creator_account.pubkey, member_pubkeys[0]];
-        let config = create_nostr_group_config_data();
+        let config = create_nostr_group_config_data(admin_pubkeys.clone());
 
         let group = whitenoise
             .create_group(
                 &creator_account,
                 member_pubkeys.clone(),
-                admin_pubkeys.clone(),
                 config,
                 None,
             )

--- a/src/whitenoise/welcomes.rs
+++ b/src/whitenoise/welcomes.rs
@@ -176,12 +176,7 @@ mod tests {
         let config = create_nostr_group_config_data(admin_pubkeys.clone());
 
         let group = whitenoise
-            .create_group(
-                &creator_account,
-                member_pubkeys.clone(),
-                config,
-                None,
-            )
+            .create_group(&creator_account, member_pubkeys.clone(), config, None)
             .await;
         assert!(group.is_ok());
         let result1 = whitenoise


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Update group data/metadata via a new action; updates are merged and propagated to relevant relays.
  - Enhanced Direct Message group handling with correct types, admins, and members.

- Refactor
  - Streamlined group creation: admin/creator keys are supplied inside group configuration rather than separate inputs.
  - Public exports adjusted to make group information and types more directly available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->