### PR TITLE
Remove nostr dependency and fix re-exports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2378,7 +2378,7 @@ checksum = "f0efe882e02d206d8d279c20eb40e03baf7cb5136a1476dc084a324fbc3ec42d"
 [[package]]
 name = "nostr"
 version = "0.43.0"
-source = "git+https://github.com/erskingardner/rust-nostr?rev=03934fc8e1e1e6c831f282cde9e13589be15c21e#03934fc8e1e1e6c831f282cde9e13589be15c21e"
+source = "git+https://github.com/erskingardner/rust-nostr?rev=5ec43be393f895622a90e3957dfc3d7d8df6d508#5ec43be393f895622a90e3957dfc3d7d8df6d508"
 dependencies = [
  "aes",
  "base64 0.22.1",
@@ -2401,7 +2401,7 @@ dependencies = [
 [[package]]
 name = "nostr-blossom"
 version = "0.43.0"
-source = "git+https://github.com/erskingardner/rust-nostr?rev=03934fc8e1e1e6c831f282cde9e13589be15c21e#03934fc8e1e1e6c831f282cde9e13589be15c21e"
+source = "git+https://github.com/erskingardner/rust-nostr?rev=5ec43be393f895622a90e3957dfc3d7d8df6d508#5ec43be393f895622a90e3957dfc3d7d8df6d508"
 dependencies = [
  "base64 0.22.1",
  "nostr",
@@ -2412,7 +2412,7 @@ dependencies = [
 [[package]]
 name = "nostr-database"
 version = "0.43.0"
-source = "git+https://github.com/erskingardner/rust-nostr?rev=03934fc8e1e1e6c831f282cde9e13589be15c21e#03934fc8e1e1e6c831f282cde9e13589be15c21e"
+source = "git+https://github.com/erskingardner/rust-nostr?rev=5ec43be393f895622a90e3957dfc3d7d8df6d508#5ec43be393f895622a90e3957dfc3d7d8df6d508"
 dependencies = [
  "flatbuffers",
  "lru",
@@ -2423,7 +2423,7 @@ dependencies = [
 [[package]]
 name = "nostr-lmdb"
 version = "0.43.0"
-source = "git+https://github.com/erskingardner/rust-nostr?rev=03934fc8e1e1e6c831f282cde9e13589be15c21e#03934fc8e1e1e6c831f282cde9e13589be15c21e"
+source = "git+https://github.com/erskingardner/rust-nostr?rev=5ec43be393f895622a90e3957dfc3d7d8df6d508#5ec43be393f895622a90e3957dfc3d7d8df6d508"
 dependencies = [
  "async-utility",
  "flume",
@@ -2437,7 +2437,7 @@ dependencies = [
 [[package]]
 name = "nostr-mls"
 version = "0.43.0"
-source = "git+https://github.com/erskingardner/rust-nostr?rev=03934fc8e1e1e6c831f282cde9e13589be15c21e#03934fc8e1e1e6c831f282cde9e13589be15c21e"
+source = "git+https://github.com/erskingardner/rust-nostr?rev=5ec43be393f895622a90e3957dfc3d7d8df6d508#5ec43be393f895622a90e3957dfc3d7d8df6d508"
 dependencies = [
  "aes-gcm",
  "nostr",
@@ -2453,7 +2453,7 @@ dependencies = [
 [[package]]
 name = "nostr-mls-sqlite-storage"
 version = "0.43.0"
-source = "git+https://github.com/erskingardner/rust-nostr?rev=03934fc8e1e1e6c831f282cde9e13589be15c21e#03934fc8e1e1e6c831f282cde9e13589be15c21e"
+source = "git+https://github.com/erskingardner/rust-nostr?rev=5ec43be393f895622a90e3957dfc3d7d8df6d508#5ec43be393f895622a90e3957dfc3d7d8df6d508"
 dependencies = [
  "nostr",
  "nostr-mls-storage",
@@ -2469,7 +2469,7 @@ dependencies = [
 [[package]]
 name = "nostr-mls-storage"
 version = "0.43.0"
-source = "git+https://github.com/erskingardner/rust-nostr?rev=03934fc8e1e1e6c831f282cde9e13589be15c21e#03934fc8e1e1e6c831f282cde9e13589be15c21e"
+source = "git+https://github.com/erskingardner/rust-nostr?rev=5ec43be393f895622a90e3957dfc3d7d8df6d508#5ec43be393f895622a90e3957dfc3d7d8df6d508"
 dependencies = [
  "nostr",
  "openmls",
@@ -2481,7 +2481,7 @@ dependencies = [
 [[package]]
 name = "nostr-relay-pool"
 version = "0.43.0"
-source = "git+https://github.com/erskingardner/rust-nostr?rev=03934fc8e1e1e6c831f282cde9e13589be15c21e#03934fc8e1e1e6c831f282cde9e13589be15c21e"
+source = "git+https://github.com/erskingardner/rust-nostr?rev=5ec43be393f895622a90e3957dfc3d7d8df6d508#5ec43be393f895622a90e3957dfc3d7d8df6d508"
 dependencies = [
  "async-utility",
  "async-wsocket",
@@ -2497,7 +2497,7 @@ dependencies = [
 [[package]]
 name = "nostr-sdk"
 version = "0.43.0"
-source = "git+https://github.com/erskingardner/rust-nostr?rev=03934fc8e1e1e6c831f282cde9e13589be15c21e#03934fc8e1e1e6c831f282cde9e13589be15c21e"
+source = "git+https://github.com/erskingardner/rust-nostr?rev=5ec43be393f895622a90e3957dfc3d7d8df6d508#5ec43be393f895622a90e3957dfc3d7d8df6d508"
 dependencies = [
  "async-utility",
  "nostr",
@@ -2583,7 +2583,7 @@ dependencies = [
 [[package]]
 name = "nwc"
 version = "0.43.0"
-source = "git+https://github.com/erskingardner/rust-nostr?rev=03934fc8e1e1e6c831f282cde9e13589be15c21e#03934fc8e1e1e6c831f282cde9e13589be15c21e"
+source = "git+https://github.com/erskingardner/rust-nostr?rev=5ec43be393f895622a90e3957dfc3d7d8df6d508#5ec43be393f895622a90e3957dfc3d7d8df6d508"
 dependencies = [
  "async-utility",
  "nostr",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4851,7 +4851,6 @@ dependencies = [
  "keyring",
  "lightning-invoice",
  "mockito",
- "nostr",
  "nostr-blossom",
  "nostr-mls",
  "nostr-mls-sqlite-storage",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,6 @@ keyring = { version = "3.6", features = [
 ] }
 lightning-invoice = "0.33.1"
 
-nostr = { version = "0.43.0", git="https://github.com/erskingardner/rust-nostr", rev = "03934fc8e1e1e6c831f282cde9e13589be15c21e", features = [ "std" ] }
 nostr-mls = { version = "0.43.0", git="https://github.com/erskingardner/rust-nostr", rev = "03934fc8e1e1e6c831f282cde9e13589be15c21e" }
 nostr-mls-sqlite-storage = { version = "0.43.0", git="https://github.com/erskingardner/rust-nostr", rev = "03934fc8e1e1e6c831f282cde9e13589be15c21e" }
 nwc = { version = "0.43.0", git="https://github.com/erskingardner/rust-nostr", rev = "03934fc8e1e1e6c831f282cde9e13589be15c21e" }
@@ -42,7 +41,6 @@ nostr-sdk = { version = "0.43.0", git="https://github.com/erskingardner/rust-nos
 ] }
 
 # LOCAL RUST_NOSTR FOR DEVELOPMENT
-# nostr = { version = "0.43", path="../rust-nostr/crates/nostr", features = [ "std" ] }
 # nostr-mls = { version = "0.43", path="../rust-nostr/mls/nostr-mls" }
 # nostr-mls-sqlite-storage = { version = "0.43", path="../rust-nostr/mls/nostr-mls-sqlite-storage" }
 # nwc = { version = "0.43", path="../rust-nostr/crates/nwc" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,11 +28,11 @@ keyring = { version = "3.6", features = [
 ] }
 lightning-invoice = "0.33.1"
 
-nostr-mls = { version = "0.43.0", git="https://github.com/erskingardner/rust-nostr", rev = "03934fc8e1e1e6c831f282cde9e13589be15c21e" }
-nostr-mls-sqlite-storage = { version = "0.43.0", git="https://github.com/erskingardner/rust-nostr", rev = "03934fc8e1e1e6c831f282cde9e13589be15c21e" }
-nwc = { version = "0.43.0", git="https://github.com/erskingardner/rust-nostr", rev = "03934fc8e1e1e6c831f282cde9e13589be15c21e" }
-nostr-blossom = { version = "0.43.0", git="https://github.com/erskingardner/rust-nostr", rev = "03934fc8e1e1e6c831f282cde9e13589be15c21e" }
-nostr-sdk = { version = "0.43.0", git="https://github.com/erskingardner/rust-nostr", rev = "03934fc8e1e1e6c831f282cde9e13589be15c21e", features = [
+nostr-mls = { version = "0.43.0", git="https://github.com/erskingardner/rust-nostr", rev = "5ec43be393f895622a90e3957dfc3d7d8df6d508" }
+nostr-mls-sqlite-storage = { version = "0.43.0", git="https://github.com/erskingardner/rust-nostr", rev = "5ec43be393f895622a90e3957dfc3d7d8df6d508" }
+nwc = { version = "0.43.0", git="https://github.com/erskingardner/rust-nostr", rev = "5ec43be393f895622a90e3957dfc3d7d8df6d508" }
+nostr-blossom = { version = "0.43.0", git="https://github.com/erskingardner/rust-nostr", rev = "5ec43be393f895622a90e3957dfc3d7d8df6d508" }
+nostr-sdk = { version = "0.43.0", git="https://github.com/erskingardner/rust-nostr", rev = "5ec43be393f895622a90e3957dfc3d7d8df6d508", features = [
     "lmdb",
     "nip04",
     "nip44",

--- a/src/integration_tests/core/context.rs
+++ b/src/integration_tests/core/context.rs
@@ -1,4 +1,5 @@
-use crate::{Account, Group, Whitenoise, WhitenoiseError};
+use crate::{Account, Whitenoise, WhitenoiseError};
+use nostr_mls::prelude::group_types::Group;
 use std::collections::HashMap;
 
 #[derive(Clone)]

--- a/src/integration_tests/test_cases/follow_management/bulk_follow_users.rs
+++ b/src/integration_tests/test_cases/follow_management/bulk_follow_users.rs
@@ -1,6 +1,7 @@
 use crate::integration_tests::core::*;
-use crate::{PublicKey, WhitenoiseError};
+use crate::WhitenoiseError;
 use async_trait::async_trait;
+use nostr_sdk::PublicKey;
 
 pub struct BulkFollowUsersTestCase {
     follower_account_name: String,

--- a/src/integration_tests/test_cases/follow_management/follow_user.rs
+++ b/src/integration_tests/test_cases/follow_management/follow_user.rs
@@ -1,6 +1,7 @@
 use crate::integration_tests::core::*;
-use crate::{PublicKey, WhitenoiseError};
+use crate::WhitenoiseError;
 use async_trait::async_trait;
+use nostr_sdk::PublicKey;
 
 pub struct FollowUserTestCase {
     follower_account_name: String,

--- a/src/integration_tests/test_cases/follow_management/unfollow_user.rs
+++ b/src/integration_tests/test_cases/follow_management/unfollow_user.rs
@@ -1,6 +1,7 @@
 use crate::integration_tests::core::*;
-use crate::{PublicKey, WhitenoiseError};
+use crate::WhitenoiseError;
 use async_trait::async_trait;
+use nostr_sdk::PublicKey;
 
 pub struct UnfollowUserTestCase {
     follower_account_name: String,

--- a/src/integration_tests/test_cases/group_membership/add_group_members.rs
+++ b/src/integration_tests/test_cases/group_membership/add_group_members.rs
@@ -1,7 +1,8 @@
 use crate::integration_tests::core::*;
-use crate::{PublicKey, WhitenoiseError};
+use crate::WhitenoiseError;
 use async_trait::async_trait;
 use nostr_mls::prelude::GroupId;
+use nostr_sdk::PublicKey;
 
 pub struct AddGroupMembersTestCase {
     admin_account_name: String,

--- a/src/integration_tests/test_cases/group_membership/remove_group_members.rs
+++ b/src/integration_tests/test_cases/group_membership/remove_group_members.rs
@@ -1,7 +1,8 @@
 use crate::integration_tests::core::*;
-use crate::{PublicKey, WhitenoiseError};
+use crate::WhitenoiseError;
 use async_trait::async_trait;
 use nostr_mls::prelude::GroupId;
+use nostr_sdk::PublicKey;
 
 pub struct RemoveGroupMembersTestCase {
     admin_account_name: String,

--- a/src/integration_tests/test_cases/metadata_management/update_metadata.rs
+++ b/src/integration_tests/test_cases/metadata_management/update_metadata.rs
@@ -53,6 +53,9 @@ impl TestCase for UpdateMetadataTestCase {
             .update_metadata(&self.metadata, context.whitenoise)
             .await?;
 
+        // Give events time to deliver and process
+        tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
+
         // Verify the update worked
         let updated_metadata = account.metadata(context.whitenoise).await?;
         assert_eq!(

--- a/src/integration_tests/test_cases/metadata_management/update_metadata.rs
+++ b/src/integration_tests/test_cases/metadata_management/update_metadata.rs
@@ -1,6 +1,7 @@
 use crate::integration_tests::core::*;
-use crate::{Metadata, WhitenoiseError};
+use crate::WhitenoiseError;
 use async_trait::async_trait;
+use nostr_sdk::Metadata;
 
 pub struct UpdateMetadataTestCase {
     account_name: String,

--- a/src/integration_tests/test_cases/subscription_processing/publish_metadata_update.rs
+++ b/src/integration_tests/test_cases/subscription_processing/publish_metadata_update.rs
@@ -49,6 +49,9 @@ impl TestCase for PublishMetadataUpdateTestCase {
         // Wait for client to connect
         tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
 
+        // Wait an additional second to ensure external event has newer timestamp than initial account metadata
+        tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+
         // Publish metadata update
         test_client
             .send_event_builder(EventBuilder::metadata(&self.updated_metadata))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,64 +14,32 @@ pub mod whitenoise;
 pub mod integration_tests;
 
 // Re-export main types for library users
-pub use nostr_manager::parser::SerializableToken;
-pub use nostr_mls::groups::NostrGroupConfigData;
-pub use types::ImageType;
-pub use types::MessageWithTokens;
-pub use whitenoise::accounts::Account;
-pub use whitenoise::app_settings::{AppSettings, ThemeMode};
+
+// Core types
+pub use types::{ImageType, MessageWithTokens};
+pub use whitenoise::{Whitenoise, WhitenoiseConfig};
+
+// Error handling
 pub use whitenoise::error::WhitenoiseError;
+
+// Account and user management
+pub use whitenoise::accounts::Account;
+pub use whitenoise::users::User;
+
+// Settings and configuration
+pub use whitenoise::app_settings::{AppSettings, ThemeMode};
+
+// Groups and relays
 pub use whitenoise::group_information::{GroupInformation, GroupType};
+pub use whitenoise::relays::{Relay, RelayType};
+
+// Messaging
 pub use whitenoise::message_aggregator::{
     ChatMessage, EmojiReaction, ReactionSummary, UserReaction,
 };
-pub use whitenoise::relays::{Relay, RelayType};
-pub use whitenoise::users::User;
-pub use whitenoise::{Whitenoise, WhitenoiseConfig};
 
-// Re-export nostr types with documentation
-//
-// Note: These types are re-exported from the `nostr` crate for convenience
-// and to ensure version compatibility. Whitenoise is tested with nostr crate
-// version as specified in Cargo.toml.
-//
-/// Nostr public key for user identification. Re-exported from [`nostr::PublicKey`](https://docs.rs/nostr/latest/nostr/key/public_key/struct.PublicKey.html).
-#[doc(alias = "pubkey")]
-#[doc(alias = "public_key")]
-pub use nostr::PublicKey;
-
-/// Nostr event containing signed data. Re-exported from [`nostr::Event`](https://docs.rs/nostr/latest/nostr/event/struct.Event.html).
-pub use nostr::Event;
-
-/// User profile metadata (name, bio, etc.). Re-exported from [`nostr::Metadata`](https://docs.rs/nostr/latest/nostr/nips/nip01/struct.Metadata.html).
-#[doc(alias = "profile")]
-pub use nostr::Metadata;
-
-/// Nostr relay URL. Re-exported from [`nostr::RelayUrl`](https://docs.rs/nostr/latest/nostr/struct.RelayUrl.html).
-pub use nostr::RelayUrl;
-pub use nostr_sdk::RelayStatus;
-
-/// Nostr event kind. Re-exported from [`nostr::Kind`](https://docs.rs/nostr/latest/nostr/struct.Kind.html).
-pub use nostr::Kind;
-
-/// Nostr event tag. Re-exported from [`nostr::Tag`](https://docs.rs/nostr/latest/nostr/event/tag/struct.Tag.html).
-pub use nostr::Tag;
-
-/// Nostr event tags. Re-exported from [`nostr::Tags`](https://docs.rs/nostr/latest/nostr/event/tag/list/struct.Tags.html).
-pub use nostr::Tags;
-
-// Nostr MLS Types
-/// Nostr MLS Group. Re-exported from [`nostr_mls::group_types::Group`](https://docs.rs/nostr-mls/latest/nostr_mls/group_types/struct.Group.html)
-pub use nostr_mls::prelude::group_types::{Group, GroupState};
-
-/// Nostr MLS Group ID. Re-exported from [`open_mls::group::GroupId`](https://latest.openmls.tech/doc/openmls/group/struct.GroupId.html)
-pub use nostr_mls::prelude::GroupId;
-
-/// Nostr MLS Message. Re-exported from [`nostr_mls::prelude::Message`](https://docs.rs/nostr-mls/latest/nostr_mls/prelude/struct.Message.html)
-pub use nostr_mls::prelude::message_types::{Message, MessageState};
-
-/// Nostr MLS Welcome. Re-exported from [`nostr_mls::prelude::Welcome`](https://docs.rs/nostr-mls/latest/nostr_mls/prelude/struct.Welcome.html)
-pub use nostr_mls::prelude::welcome_types::{Welcome, WelcomeState};
+// Nostr integration
+pub use nostr_manager::parser::SerializableToken;
 
 static TRACING_GUARDS: OnceLock<Mutex<Option<(WorkerGuard, WorkerGuard)>>> = OnceLock::new();
 static TRACING_INIT: OnceLock<()> = OnceLock::new();

--- a/src/nostr_manager/mod.rs
+++ b/src/nostr_manager/mod.rs
@@ -36,7 +36,7 @@ pub enum NostrManagerError {
     #[error("Failed to connect to any relays")]
     NoRelayConnections,
     #[error("Nostr Event error: {0}")]
-    NostrEventBuilderError(#[from] nostr::event::builder::Error),
+    NostrEventBuilderError(#[from] nostr_sdk::event::builder::Error),
     #[error("Serialization error: {0}")]
     SerializationError(#[from] serde_json::Error),
     #[error("Event processing error: {0}")]

--- a/src/nostr_manager/mod.rs
+++ b/src/nostr_manager/mod.rs
@@ -537,16 +537,9 @@ impl NostrManager {
                 "Connecting to {} newly added relays",
                 newly_added_relays.len()
             );
-
-            // The connect() method is async but we don't wait for full connection
-            // as subscription setup should work even with partially connected relays
-            tokio::spawn({
-                let client = self.client.clone();
-                async move {
-                    client.connect().await;
-                }
-            });
         }
+
+        self.client.connect().await;
 
         tracing::debug!(
             target: "whitenoise::nostr_manager::ensure_relays_connected",

--- a/src/nostr_manager/parser.rs
+++ b/src/nostr_manager/parser.rs
@@ -1,6 +1,6 @@
 //! This module contains the logic for parsing Nostr events into tokens.
 
-use nostr::parser::{NostrParser, Token};
+use nostr_sdk::parser::{NostrParser, Token};
 use serde::{Deserialize, Serialize};
 
 use crate::nostr_manager::NostrManager;

--- a/src/whitenoise/accounts.rs
+++ b/src/whitenoise/accounts.rs
@@ -878,9 +878,9 @@ impl Whitenoise {
 
 #[cfg(test)]
 pub mod test_utils {
-    use nostr::key::PublicKey;
     use nostr_mls::NostrMls;
     use nostr_mls_sqlite_storage::NostrMlsSqliteStorage;
+    use nostr_sdk::key::PublicKey;
     use std::path::PathBuf;
     use tempfile::TempDir;
 

--- a/src/whitenoise/accounts.rs
+++ b/src/whitenoise/accounts.rs
@@ -880,7 +880,7 @@ impl Whitenoise {
 pub mod test_utils {
     use nostr_mls::NostrMls;
     use nostr_mls_sqlite_storage::NostrMlsSqliteStorage;
-    use nostr_sdk::key::PublicKey;
+    use nostr_sdk::PublicKey;
     use std::path::PathBuf;
     use tempfile::TempDir;
 

--- a/src/whitenoise/database/accounts.rs
+++ b/src/whitenoise/database/accounts.rs
@@ -1055,8 +1055,8 @@ mod tests {
             .name("ComplexUser")
             .display_name("Complex User Display")
             .about("A user with comprehensive metadata including special characters: 🚀 and emojis")
-            .picture(nostr::types::url::Url::parse("https://example.com/avatar.jpg").unwrap())
-            .banner(nostr::types::url::Url::parse("https://example.com/banner.jpg").unwrap())
+            .picture(nostr_sdk::types::url::Url::parse("https://example.com/avatar.jpg").unwrap())
+            .banner(nostr_sdk::types::url::Url::parse("https://example.com/banner.jpg").unwrap())
             .nip05("complex@example.com")
             .lud06("lnurl1dp68gurn8ghj7urp0v4kxvern9eehqurfdcsk6arpdd5kuemmduhxcmmrdaehgu3wd3skuep0dejhctnwda3kxvd09eszuekd0v8rqnrpwcxk7trj0ae8gmmwv9unx2txvg6xqmwpwejkcmmfd9c");
 

--- a/src/whitenoise/database/accounts.rs
+++ b/src/whitenoise/database/accounts.rs
@@ -1032,6 +1032,7 @@ mod tests {
     async fn test_follows_with_complex_user_metadata() {
         use crate::whitenoise::test_utils::create_mock_whitenoise;
         use crate::whitenoise::users::User;
+        use nostr_sdk::prelude::Url;
 
         let (whitenoise, _data_temp, _logs_temp) = create_mock_whitenoise().await;
 
@@ -1057,8 +1058,8 @@ mod tests {
             .name("ComplexUser")
             .display_name("Complex User Display")
             .about("A user with comprehensive metadata including special characters: 🚀 and emojis")
-            .picture(nostr_sdk::types::url::Url::parse("https://example.com/avatar.jpg").unwrap())
-            .banner(nostr_sdk::types::url::Url::parse("https://example.com/banner.jpg").unwrap())
+            .picture(Url::parse("https://example.com/avatar.jpg").unwrap())
+            .banner(Url::parse("https://example.com/banner.jpg").unwrap())
             .nip05("complex@example.com")
             .lud06("lnurl1dp68gurn8ghj7urp0v4kxvern9eehqurfdcsk6arpdd5kuemmduhxcmmrdaehgu3wd3skuep0dejhctnwda3kxvd09eszuekd0v8rqnrpwcxk7trj0ae8gmmwv9unx2txvg6xqmwpwejkcmmfd9c");
 

--- a/src/whitenoise/database/accounts.rs
+++ b/src/whitenoise/database/accounts.rs
@@ -181,7 +181,7 @@ impl Account {
         .bind(self.id)
         .fetch_all(&database.pool)
         .await
-        .map_err(|_| WhitenoiseError::AccountNotFound)?;
+        .map_err(DatabaseError::Sqlx)?;
 
         let users = user_rows
             .into_iter()
@@ -222,7 +222,8 @@ impl Account {
         .bind(self.id)
         .bind(user.id)
         .fetch_one(&database.pool)
-        .await?;
+        .await
+        .map_err(DatabaseError::Sqlx)?;
         Ok(result.get::<i64, _>(0) > 0)
     }
 
@@ -280,7 +281,8 @@ impl Account {
             .bind(self.id)
             .bind(user.id)
             .execute(&database.pool)
-            .await?;
+            .await
+            .map_err(DatabaseError::Sqlx)?;
         Ok(())
     }
 

--- a/src/whitenoise/database/user_relays.rs
+++ b/src/whitenoise/database/user_relays.rs
@@ -4,7 +4,7 @@ use super::utils::parse_timestamp;
 use crate::whitenoise::relays::RelayType;
 
 #[derive(Debug, PartialEq, Eq, Clone, Hash)]
-pub(crate) struct UserRelayRow {
+pub struct UserRelayRow {
     // user_id is the ID of the user
     pub user_id: i64,
     // relay_id is the ID of the relay

--- a/src/whitenoise/database/users.rs
+++ b/src/whitenoise/database/users.rs
@@ -760,8 +760,8 @@ mod tests {
                 Metadata::new()
                     .name("Full User")
                     .display_name("Full Display")
-                    .picture(nostr::types::url::Url::parse("https://example.com/avatar.jpg").unwrap())
-                    .banner(nostr::types::url::Url::parse("https://example.com/banner.jpg").unwrap())
+                    .picture(nostr_sdk::types::url::Url::parse("https://example.com/avatar.jpg").unwrap())
+                    .banner(nostr_sdk::types::url::Url::parse("https://example.com/banner.jpg").unwrap())
                     .about("Full about")
                     .nip05("full@example.com")
                     .lud06("lnurl1dp68gurn8ghj7urp0v4kxvern9eehqurfdcsk6arpdd5kuemmduhxcmmrdaehgu3wd3skuep0dejhctnwda3kxvd09eszuekd0v8rqnrpwcxk7trj0ae8gmmwv9unx2txvg6xqmwpwejkcmmfd9c"),

--- a/src/whitenoise/error.rs
+++ b/src/whitenoise/error.rs
@@ -53,7 +53,7 @@ pub enum WhitenoiseError {
     #[error("Account not authorized")]
     AccountNotAuthorized,
 
-    #[error("Nostr Mls error: {0}")]
+    #[error("Nostr MLS error: {0}")]
     NostrMlsError(#[from] nostr_mls::Error),
 
     #[error("Invalid event: {0}")]
@@ -98,7 +98,7 @@ pub enum WhitenoiseError {
     #[error("Welcome not found")]
     WelcomeNotFound,
 
-    #[error("nip04 direcet message error")]
+    #[error("nip04 direct message error")]
     Nip04Error(#[from] nostr_sdk::nips::nip04::Error),
 
     #[error("join error due to spawn blocking")]

--- a/src/whitenoise/error.rs
+++ b/src/whitenoise/error.rs
@@ -72,10 +72,10 @@ pub enum WhitenoiseError {
     NostrKey(#[from] nostr_sdk::key::Error),
 
     #[error("Nostr url error: {0}")]
-    NostrUrl(#[from] nostr::types::url::Error),
+    NostrUrl(#[from] nostr_sdk::types::url::Error),
 
     #[error("Nostr tag error: {0}")]
-    NostrTag(#[from] nostr::event::tag::Error),
+    NostrTag(#[from] nostr_sdk::event::tag::Error),
 
     #[error("Database error: {0}")]
     Database(#[from] DatabaseError),
@@ -99,7 +99,7 @@ pub enum WhitenoiseError {
     WelcomeNotFound,
 
     #[error("nip04 direcet message error")]
-    Nip04Error(#[from] nostr::nips::nip04::Error),
+    Nip04Error(#[from] nostr_sdk::nips::nip04::Error),
 
     #[error("join error due to spawn blocking")]
     JoinError(#[from] tokio::task::JoinError),

--- a/src/whitenoise/event_processor/event_handlers/handle_metadata.rs
+++ b/src/whitenoise/event_processor/event_handlers/handle_metadata.rs
@@ -8,12 +8,31 @@ use crate::whitenoise::{
 
 impl Whitenoise {
     pub async fn handle_metadata(&self, event: Event) -> Result<()> {
-        let (mut user, _newly_created) =
+        let (mut user, newly_created) =
             User::find_or_create_by_pubkey(&event.pubkey, &self.database).await?;
         match Metadata::from_json(&event.content) {
             Ok(metadata) => {
-                user.metadata = metadata;
-                let _ = user.save(&self.database).await?;
+                // Only update metadata if this event is newer than our current data
+                // For newly created users, always accept the metadata
+                let event_timestamp = event.created_at.as_u64() as i64;
+                if newly_created || event_timestamp > user.updated_at.timestamp() {
+                    user.metadata = metadata;
+                    let _ = user.save(&self.database).await?;
+                    tracing::debug!(
+                        target: "whitenoise::event_processor::handle_metadata",
+                        "Updated metadata for user {} with event timestamp {}",
+                        event.pubkey,
+                        event_timestamp
+                    );
+                } else {
+                    tracing::debug!(
+                        target: "whitenoise::event_processor::handle_metadata",
+                        "Ignoring stale metadata event for user {} (event: {}, current: {})",
+                        event.pubkey,
+                        event_timestamp,
+                        user.updated_at.timestamp()
+                    );
+                }
                 Ok(())
             }
             Err(e) => {

--- a/src/whitenoise/follows.rs
+++ b/src/whitenoise/follows.rs
@@ -1,4 +1,4 @@
-use nostr_sdk::key::PublicKey;
+use nostr_sdk::PublicKey;
 
 use crate::whitenoise::{accounts::Account, error::Result, users::User, Whitenoise};
 

--- a/src/whitenoise/follows.rs
+++ b/src/whitenoise/follows.rs
@@ -1,4 +1,4 @@
-use nostr::key::PublicKey;
+use nostr_sdk::key::PublicKey;
 
 use crate::whitenoise::{accounts::Account, error::Result, users::User, Whitenoise};
 

--- a/src/whitenoise/message_aggregator/mod.rs
+++ b/src/whitenoise/message_aggregator/mod.rs
@@ -20,6 +20,7 @@ pub use types::{
 
 use nostr_mls::prelude::message_types::Message;
 use nostr_mls::prelude::*;
+use nostr_sdk::PublicKey;
 
 use crate::nostr_manager::parser::Parser;
 

--- a/src/whitenoise/message_aggregator/mod.rs
+++ b/src/whitenoise/message_aggregator/mod.rs
@@ -18,10 +18,10 @@ pub use types::{
     ReactionSummary, UserReaction,
 };
 
+use nostr_mls::prelude::message_types::Message;
 use nostr_mls::prelude::*;
 
 use crate::nostr_manager::parser::Parser;
-use crate::Message;
 
 /// Main message aggregator - designed to be a singleton per Whitenoise instance
 /// Group-aware to ensure proper isolation between different group conversations

--- a/src/whitenoise/message_aggregator/processor.rs
+++ b/src/whitenoise/message_aggregator/processor.rs
@@ -3,7 +3,7 @@
 //! This module implements the stateless message aggregation algorithm that transforms
 //! raw Nostr MLS messages into structured ChatMessage objects.
 
-use nostr::prelude::*;
+use nostr_sdk::prelude::*;
 use std::collections::HashMap;
 
 use super::reaction_handler;
@@ -11,7 +11,7 @@ use super::types::{
     AggregatorConfig, ChatMessage, ProcessingError, UnresolvedMessage, UnresolvedReason,
 };
 use crate::nostr_manager::parser::Parser;
-use crate::Message;
+use nostr_mls::prelude::message_types::Message;
 
 /// Process raw messages into aggregated chat messages
 /// This implements the Phase 1 stateless algorithm from the plan

--- a/src/whitenoise/message_aggregator/processor.rs
+++ b/src/whitenoise/message_aggregator/processor.rs
@@ -30,7 +30,7 @@ pub async fn process_messages(
 
     // Step 2: Sort messages by timestamp for chronological processing
     let mut sorted_messages = messages;
-    sorted_messages.sort_by(|a, b| a.created_at.cmp(&b.created_at));
+    sorted_messages.sort_unstable_by(|a, b| a.created_at.cmp(&b.created_at));
 
     if config.enable_debug_logging {
         tracing::debug!("Sorted {} messages chronologically", sorted_messages.len());

--- a/src/whitenoise/message_aggregator/reaction_handler.rs
+++ b/src/whitenoise/message_aggregator/reaction_handler.rs
@@ -98,8 +98,15 @@ fn extract_target_message_id(tags: &Tags) -> Result<String, ProcessingError> {
                 return Ok(event_id.to_string());
             }
         }
+        // Fallback: parameterized replaceable event ("a" tag)
+        for tag in tags.iter() {
+            if tag.kind() == TagKind::SingleLetter(SingleLetterTag::lowercase(Alphabet::A)) {
+                if let Some(addr) = tag.content() {
+                    return Ok(addr.to_string());
+                }
+            }
+        }
     }
-
     Err(ProcessingError::MissingETag)
 }
 

--- a/src/whitenoise/message_aggregator/reaction_handler.rs
+++ b/src/whitenoise/message_aggregator/reaction_handler.rs
@@ -3,7 +3,7 @@
 //! This module handles the processing of reaction messages (kind 7) and manages
 //! the aggregation of reactions on target messages.
 
-use nostr::prelude::*;
+use nostr_sdk::prelude::*;
 use std::collections::HashMap;
 
 use super::emoji_utils;
@@ -11,7 +11,7 @@ use super::types::{
     AggregatorConfig, ChatMessage, EmojiReaction, ProcessingError, UnresolvedMessage,
     UnresolvedReason, UserReaction,
 };
-use crate::Message;
+use nostr_mls::prelude::message_types::Message;
 
 /// Process a reaction message and update the target message's reaction summary
 pub fn process_reaction(

--- a/src/whitenoise/message_aggregator/tests.rs
+++ b/src/whitenoise/message_aggregator/tests.rs
@@ -8,7 +8,7 @@
 mod integration_tests {
     use super::super::*;
     use crate::nostr_manager::parser::MockParser;
-    use nostr::prelude::*;
+    use nostr_sdk::prelude::*;
 
     #[tokio::test]
     async fn test_empty_messages_integration() {

--- a/src/whitenoise/message_aggregator/types.rs
+++ b/src/whitenoise/message_aggregator/types.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 use crate::nostr_manager::parser::SerializableToken;
-use crate::Message;
+use nostr_mls::prelude::message_types::Message;
 
 /// Represents an aggregated chat message ready for frontend display
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/src/whitenoise/message_aggregator/types.rs
+++ b/src/whitenoise/message_aggregator/types.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 use crate::nostr_manager::parser::SerializableToken;
-use nostr_mls::prelude::message_types::Message;
+pub type MlsMessage = nostr_mls::prelude::message_types::Message;
 
 /// Represents an aggregated chat message ready for frontend display
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -81,7 +81,7 @@ pub struct UserReaction {
 /// Internal type for tracking unresolved references
 #[derive(Debug, Clone)]
 pub(crate) struct UnresolvedMessage {
-    pub message: Message,
+    pub message: MlsMessage,
     pub retry_count: u8,
     pub reason: UnresolvedReason,
 }

--- a/src/whitenoise/utils.rs
+++ b/src/whitenoise/utils.rs
@@ -1,4 +1,4 @@
-use nostr_sdk::{types::RelayUrl, PublicKey, ToBech32};
+use nostr_sdk::{PublicKey, ToBech32};
 
 use crate::whitenoise::{error::WhitenoiseError, Whitenoise};
 

--- a/src/whitenoise/utils.rs
+++ b/src/whitenoise/utils.rs
@@ -41,21 +41,6 @@ impl Whitenoise {
         Ok(public_key.to_hex())
     }
 
-    pub fn parse_relays_from_sql(
-        relays: String,
-    ) -> core::result::Result<Vec<RelayUrl>, sqlx::Error> {
-        serde_json::from_str(&relays)
-            .map(|urls: Vec<String>| {
-                urls.iter()
-                    .filter_map(|url| RelayUrl::parse(url).ok())
-                    .collect::<Vec<_>>()
-            })
-            .map_err(|e| sqlx::Error::ColumnDecode {
-                index: "nip65_relays".to_owned(),
-                source: Box::new(e),
-            })
-    }
-
     /// Capitalizes the first letter of a word, leaving the rest unchanged
     pub(crate) fn capitalize_first_letter(word: &str) -> String {
         let mut chars = word.chars();
@@ -76,34 +61,6 @@ mod tests {
         assert_eq!(Whitenoise::capitalize_first_letter("5atoshi"), "5atoshi");
         assert_eq!(Whitenoise::capitalize_first_letter(""), "");
         assert_eq!(Whitenoise::capitalize_first_letter("ßtraße"), "SStraße");
-    }
-
-    #[test]
-    fn test_parse_relays_from_sql() {
-        let json_relays = r#"["wss://relay1.example.com", "wss://relay2.example.com"]"#;
-        let result = Whitenoise::parse_relays_from_sql(json_relays.to_string());
-
-        assert!(result.is_ok());
-        let relays = result.unwrap();
-        assert_eq!(relays.len(), 2);
-        assert!(relays.contains(&RelayUrl::parse("wss://relay1.example.com").unwrap()));
-        assert!(relays.contains(&RelayUrl::parse("wss://relay2.example.com").unwrap()));
-
-        let empty_json = "[]";
-        let empty_result = Whitenoise::parse_relays_from_sql(empty_json.to_string());
-        assert!(empty_result.is_ok());
-        assert_eq!(empty_result.unwrap().len(), 0);
-
-        let mixed_json = r#"["wss://relay1.example.com","not a url"]"#;
-        let mixed_result = Whitenoise::parse_relays_from_sql(mixed_json.to_string());
-        assert!(mixed_result.is_ok());
-        let relays = mixed_result.unwrap();
-        assert_eq!(relays.len(), 1);
-        assert!(relays.contains(&RelayUrl::parse("wss://relay1.example.com").unwrap()));
-
-        let invalid_json = "invalid json";
-        let invalid_result = Whitenoise::parse_relays_from_sql(invalid_json.to_string());
-        assert!(invalid_result.is_err());
     }
 
     #[test]

--- a/src/whitenoise/utils.rs
+++ b/src/whitenoise/utils.rs
@@ -1,4 +1,4 @@
-use nostr::{types::RelayUrl, PublicKey, ToBech32};
+use nostr_sdk::{types::RelayUrl, PublicKey, ToBech32};
 
 use crate::whitenoise::{error::WhitenoiseError, Whitenoise};
 


### PR DESCRIPTION
This was a bit of a bone-headed issue on reflection. 

nostr and nostr_sdk shouldn't be both included as dependencies. It meant that we were using structs from both and confusing types at certain points. 

Also, it's easier/safer to let Cargo handle transitive dependencies so i've removed lots of the reexports and I'm going to add nostr_sdk and nostr_mls to the FRB crate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Reorganized Nostr/MLS integrations and unified message types for more consistent message processing; several public types and exports were consolidated or relocated.
  - Added freshness checks to metadata handling to ignore stale updates.

- Chores
  - Updated Nostr-related dependencies to a newer revision across related crates.
  - Relay connection now waits for establishment before proceeding.

- Tests
  - Updated test imports and utilities to align with the new libraries.

- Note
  - Minor runtime behavior changes: metadata freshness gating and synchronous relay connects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->