### PR TITLE
test: add sleep to failing integration test

### DIFF
--- a/src/integration_tests/test_cases/follow_management/follow_user.rs
+++ b/src/integration_tests/test_cases/follow_management/follow_user.rs
@@ -35,7 +35,7 @@ impl TestCase for FollowUserTestCase {
             .await?;
 
         // Add small delay for async operations
-        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+        tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
 
         let is_following = context
             .whitenoise

--- a/src/integration_tests/test_cases/subscription_processing/publish_relay_list_update.rs
+++ b/src/integration_tests/test_cases/subscription_processing/publish_relay_list_update.rs
@@ -40,6 +40,7 @@ impl TestCase for PublishRelayListUpdateTestCase {
 
         // Create external client
         let test_client = create_test_client(&context.dev_relays, keys.clone()).await?;
+        tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
         let relay_urls: Vec<String> = dev_relay_urls.iter().map(|url| url.to_string()).collect();
         publish_relay_lists(&test_client, relay_urls).await?;
 


### PR DESCRIPTION
# Context
In #336 checks were passing but in master integrations tests failed in ubuntu. Sometimes integration tests need some sleep 😴 😅  and  in theat PR I removed one sleep that apparently was necessary in the publish relays list test case.

Also, locally, I was having trouble with the follows scenario in the integration tests, and now I noticed that a longer sleep there fixed my issue too

# What has been done
- 2 sleeps added in integration tests to hopefully fix the issue in master

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Increased post-action wait time in follow management scenarios to reduce flakiness.
  * Added a brief delay after client initialization in subscription processing to stabilize relay list updates.
  * Aims to improve reliability in asynchronous flows and decrease timing-related test failures in CI.
  * No changes to user-facing functionality; these adjustments solely enhance test stability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->