### PR TITLE
Feat/account subscription refresh

### DIFF
--- a/src/nostr_manager/mod.rs
+++ b/src/nostr_manager/mod.rs
@@ -251,12 +251,10 @@ impl NostrManager {
             "Updating account subscriptions with cleanup for relay changes"
         );
         self.client.set_signer(signer).await;
-        let buffer_time = Timestamp::now() - Duration::from_secs(10);
-
-        self.unsubscribe_account_subscriptions(&pubkey).await?;
-
-        let result = self
-            .setup_account_subscriptions(
+        let result = async {
+            let buffer_time = Timestamp::now() - Duration::from_secs(10);
+            self.unsubscribe_account_subscriptions(&pubkey).await?;
+            self.setup_account_subscriptions(
                 pubkey,
                 user_relays,
                 inbox_relays,
@@ -264,7 +262,9 @@ impl NostrManager {
                 nostr_group_ids,
                 Some(buffer_time),
             )
-            .await;
+            .await
+        }
+        .await;
         self.client.unset_signer().await;
         result
     }

--- a/src/whitenoise/accounts.rs
+++ b/src/whitenoise/accounts.rs
@@ -804,64 +804,66 @@ impl Whitenoise {
         Ok(())
     }
 
+    /// Extract group data including relay URLs and group IDs for subscription setup.
+    async fn extract_groups_relays_and_ids(
+        &self,
+        account: &Account,
+    ) -> Result<(Vec<RelayUrl>, Vec<String>)> {
+        let nostr_mls = Account::create_nostr_mls(account.pubkey, &self.config.data_dir)?;
+        let groups = nostr_mls.get_groups()?;
+        let mut group_relays_set = HashSet::new();
+        let mut group_ids = vec![];
+
+        for group in &groups {
+            let relays = nostr_mls.get_relays(&group.mls_group_id)?;
+            group_relays_set.extend(relays);
+            group_ids.push(hex::encode(group.nostr_group_id));
+        }
+
+        let group_relays_urls = group_relays_set.into_iter().collect::<Vec<_>>();
+
+        Ok((group_relays_urls, group_ids))
+    }
+
     pub(crate) async fn setup_subscriptions(&self, account: &Account) -> Result<()> {
         tracing::debug!(
             target: "whitenoise::setup_subscriptions",
             "Setting up subscriptions for account: {:?}",
             account
         );
-        let mut group_relays = HashSet::new();
-        let groups: Vec<group_types::Group>;
-        {
-            let nostr_mls = Account::create_nostr_mls(account.pubkey, &self.config.data_dir)?;
-            groups = nostr_mls.get_groups()?;
-            // Collect all relays from all groups into a single vector
-            for group in &groups {
-                let relays = nostr_mls.get_relays(&group.mls_group_id)?;
-                for relay in relays {
-                    group_relays.insert(relay.clone());
-                }
-            }
-        };
-        tracing::debug!(
-            target: "whitenoise::setup_subscriptions",
-            "Found {} groups",
-            groups.len()
-        );
-        // We do this in two stages to deduplicate the relays
-        let mut group_relays_vec = Vec::new();
-        for relay in group_relays {
-            group_relays_vec.push(Relay::find_or_create_by_url(&relay, &self.database).await?);
+
+        let user_relays: Vec<RelayUrl> = account
+            .nip65_relays(self)
+            .await?
+            .into_iter()
+            .map(|r| r.url)
+            .collect();
+
+        let inbox_relays: Vec<RelayUrl> = account
+            .inbox_relays(self)
+            .await?
+            .into_iter()
+            .map(|r| r.url)
+            .collect();
+
+        let (group_relays_urls, nostr_group_ids) =
+            self.extract_groups_relays_and_ids(account).await?;
+
+        // Ensure group relays are in the database
+        for relay_url in &group_relays_urls {
+            Relay::find_or_create_by_url(relay_url, &self.database).await?;
         }
 
-        tracing::debug!(
-            target: "whitenoise::setup_subscriptions",
-            "Found {} group relays",
-            group_relays_vec.len()
-        );
-
-        let nostr_group_ids = groups
-            .into_iter()
-            .map(|group| hex::encode(group.nostr_group_id))
-            .collect::<Vec<String>>();
-
-        // Use the signer-aware subscription setup method
         let keys = self
             .secrets_store
             .get_nostr_keys_for_pubkey(&account.pubkey)?;
 
-        let user_relays = account.nip65_relays(self).await?;
-        tracing::debug!(
-            target: "whitenoise::setup_subscriptions",
-            "About to setup account subscriptions with user relays: {:?}",
-            user_relays
-        );
         self.nostr
             .setup_account_subscriptions_with_signer(
                 account.pubkey,
-                &account.nip65_relays(self).await?,
-                &account.inbox_relays(self).await?,
-                &group_relays_vec,
+                &user_relays,
+                &inbox_relays,
+                &group_relays_urls,
                 &nostr_group_ids,
                 keys,
             )
@@ -872,6 +874,56 @@ impl Whitenoise {
             "Subscriptions setup"
         );
         Ok(())
+    }
+
+    /// Refresh account subscriptions.
+    ///
+    /// This method updates subscriptions when account state changes (group membership, relay preferences).
+    /// Uses explicit cleanup to handle relay changes properly - NIP-01 auto-replacement only works
+    /// within the same relay, so changing relays would leave orphaned subscriptions without cleanup.
+    ///
+    /// # Arguments
+    ///
+    /// * `account` - The account to refresh subscriptions for
+    pub(crate) async fn refresh_account_subscriptions(&self, account: &Account) -> Result<()> {
+        tracing::debug!(
+            target: "whitenoise::refresh_account_subscriptions",
+            "Refreshing account subscriptions for account: {:?}",
+            account.pubkey
+        );
+
+        let user_relays: Vec<RelayUrl> = account
+            .nip65_relays(self)
+            .await?
+            .into_iter()
+            .map(|r| r.url)
+            .collect();
+
+        let inbox_relays: Vec<RelayUrl> = account
+            .inbox_relays(self)
+            .await?
+            .into_iter()
+            .map(|r| r.url)
+            .collect();
+
+        let (group_relays_urls, nostr_group_ids) =
+            self.extract_groups_relays_and_ids(account).await?;
+
+        let keys = self
+            .secrets_store
+            .get_nostr_keys_for_pubkey(&account.pubkey)?;
+
+        self.nostr
+            .update_account_subscriptions_with_signer(
+                account.pubkey,
+                &user_relays,
+                &inbox_relays,
+                &group_relays_urls,
+                &nostr_group_ids,
+                keys,
+            )
+            .await
+            .map_err(WhitenoiseError::from)
     }
 }
 

--- a/src/whitenoise/groups.rs
+++ b/src/whitenoise/groups.rs
@@ -186,7 +186,7 @@ impl Whitenoise {
         self.nostr
             .setup_group_messages_subscriptions_with_signer(
                 creator_account.pubkey,
-                &group_relays.into_iter().collect::<Vec<_>>(),
+                &relays.into_iter().map(|r| r.url).collect::<Vec<_>>(),
                 &group_ids,
                 keys,
             )

--- a/src/whitenoise/groups.rs
+++ b/src/whitenoise/groups.rs
@@ -178,15 +178,15 @@ impl Whitenoise {
         }
 
         let mut relays = HashSet::new();
-        for relay_url in group_relays {
-            let db_relay = self.find_or_create_relay_by_url(&relay_url).await?;
+        for relay_url in &group_relays {
+            let db_relay = self.find_or_create_relay_by_url(relay_url).await?;
             relays.insert(db_relay);
         }
 
         self.nostr
             .setup_group_messages_subscriptions_with_signer(
                 creator_account.pubkey,
-                &relays.into_iter().collect::<Vec<_>>(),
+                &group_relays.into_iter().collect::<Vec<_>>(),
                 &group_ids,
                 keys,
             )

--- a/src/whitenoise/welcomes.rs
+++ b/src/whitenoise/welcomes.rs
@@ -105,15 +105,17 @@ impl Whitenoise {
         let (group_ids, group_relays) = result;
 
         let mut relays = HashSet::new();
-        for relay in group_relays {
-            let db_relay = Relay::find_or_create_by_url(&relay, &self.database).await?;
+        for relay in &group_relays {
+            let db_relay = Relay::find_or_create_by_url(relay, &self.database).await?;
             relays.insert(db_relay);
         }
+
+        let group_relays_urls = group_relays.into_iter().collect::<Vec<_>>();
 
         self.nostr
             .setup_group_messages_subscriptions_with_signer(
                 *pubkey,
-                &relays.into_iter().collect::<Vec<_>>(),
+                &group_relays_urls,
                 &group_ids,
                 keys,
             )


### PR DESCRIPTION
Refreshes subscriptions on relay changes

Addresses #210 


Note:

* Because the 'leave_group' functionality is still in progress, this is still one part where we should update the subscriptions.
* Group creation new subscription was already being handled (by calling `NostrManager#setup_group_messages_subscriptions_with_signer`) the same is the case for `accept_welcome`

Question:

* Should we also update the account subscriptions on mls commit messages due to the possibility of the nostr_group_id changing?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Subscriptions auto-refresh when your relay list changes.
  * Added a manual refresh action to update an account’s subscriptions.
  * Logout now attempts to clean up account-specific subscriptions.

* **Behavior Changes**
  * Group message subscriptions now consistently use relay URLs across devices.
  * Event syncing can start from a recent timestamp to reduce catch-up noise.

* **Reliability Improvements**
  * Subscription updates use a short buffer and improved logging to avoid missed events during relay changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->