### PR TITLE
perf(nostr_manager): increase parallelization and reduce scope of signer lock

### DIFF
--- a/src/nostr_manager/mod.rs
+++ b/src/nostr_manager/mod.rs
@@ -389,59 +389,10 @@ impl NostrManager {
             relay_urls.len()
         );
 
-        // Track newly added relays for connection
-        let mut newly_added_relays = Vec::new();
-
-        for relay_url in relay_urls.iter() {
-            // Check if we're already connected to this relay by attempting to get its status
-            match self.client.relay(relay_url).await {
-                Ok(_) => {
-                    // Relay already exists in the client, skip
-                    tracing::debug!(
-                        target: "whitenoise::nostr_manager::ensure_relays_connected",
-                        "Relay {} already connected",
-                        relay_url
-                    );
-                }
-                Err(_) => {
-                    // Relay not found in client, add it
-                    tracing::debug!(
-                        target: "whitenoise::nostr_manager::ensure_relays_connected",
-                        "Adding new relay: {}",
-                        relay_url
-                    );
-
-                    match self.client.add_relay(relay_url.clone()).await {
-                        Ok(_) => {
-                            newly_added_relays.push(relay_url.clone());
-                            tracing::debug!(
-                                target: "whitenoise::nostr_manager::ensure_relays_connected",
-                                "Successfully added relay: {}",
-                                relay_url
-                            );
-                        }
-                        Err(e) => {
-                            tracing::warn!(
-                                target: "whitenoise::nostr_manager::ensure_relays_connected",
-                                "Failed to add relay {}: {}",
-                                relay_url,
-                                e
-                            );
-                            // Continue with other relays rather than failing completely
-                        }
-                    }
-                }
-            }
-        }
-
-        // If we added any new relays, trigger connection to establish them
-        if !newly_added_relays.is_empty() {
-            tracing::debug!(
-                target: "whitenoise::nostr_manager::ensure_relays_connected",
-                "Connecting to {} newly added relays",
-                newly_added_relays.len()
-            );
-        }
+        let relay_futures = relay_urls
+            .iter()
+            .map(|relay_url| self.ensure_relay_in_client(relay_url));
+        futures::future::join_all(relay_futures).await;
 
         self.client.connect().await;
 
@@ -451,6 +402,48 @@ impl NostrManager {
         );
 
         Ok(())
+    }
+
+    /// Ensures that the client is connected to the specified relay URL.
+    async fn ensure_relay_in_client(&self, relay_url: &RelayUrl) -> Result<()> {
+        match self.client.relay(relay_url).await {
+            Ok(_) => {
+                tracing::debug!(
+                    target: "whitenoise::nostr_manager::ensure_relays_connected",
+                    "Relay {} already connected",
+                    relay_url
+                );
+                Ok(())
+            }
+            Err(_) => {
+                // Relay not found in client, add it
+                tracing::debug!(
+                    target: "whitenoise::nostr_manager::ensure_relays_connected",
+                    "Adding new relay: {}",
+                    relay_url
+                );
+
+                match self.client.add_relay(relay_url.clone()).await {
+                    Ok(_) => {
+                        tracing::debug!(
+                            target: "whitenoise::nostr_manager::ensure_relays_connected",
+                            "Successfully added relay: {}",
+                            relay_url
+                        );
+                        Ok(())
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            target: "whitenoise::nostr_manager::ensure_relays_connected",
+                            "Failed to add relay {}: {}",
+                            relay_url,
+                            e
+                        );
+                        Err(NostrManagerError::Client(e))
+                    }
+                }
+            }
+        }
     }
 
     /// Syncs all user data from the Nostr network for an account and their contacts.

--- a/src/nostr_manager/mod.rs
+++ b/src/nostr_manager/mod.rs
@@ -287,43 +287,6 @@ impl NostrManager {
         .await
     }
 
-    pub(crate) async fn setup_batched_relay_subscriptions_with_signer(
-        &self,
-        users_with_relays: Vec<(PublicKey, Vec<RelayUrl>)>,
-        default_relays: &[RelayUrl],
-        signer: impl NostrSigner + 'static,
-    ) -> Result<()> {
-        tracing::debug!(
-            target: "whitenoise::nostr_manager::setup_batched_relay_subscriptions_with_signer",
-            "Setting up batched relay subscriptions with signer (users={}, defaults={})",
-            users_with_relays.len(),
-            default_relays.len()
-        );
-        self.with_signer(signer, || async {
-            self.setup_batched_relay_subscriptions(users_with_relays, default_relays)
-                .await
-        })
-        .await
-    }
-
-    pub(crate) async fn refresh_user_global_subscriptions_with_signer(
-        &self,
-        user_pubkey: PublicKey,
-        users_with_relays: Vec<(PublicKey, Vec<RelayUrl>)>,
-        default_relays: &[RelayUrl],
-        signer: impl NostrSigner + 'static,
-    ) -> Result<()> {
-        tracing::debug!(
-            target: "whitenoise::nostr_manager::refresh_user_global_subscriptions_with_signer",
-            "Refreshing user global subscriptions with signer"
-        );
-        self.with_signer(signer, || async {
-            self.refresh_user_global_subscriptions(user_pubkey, users_with_relays, default_relays)
-                .await
-        })
-        .await
-    }
-
     /// Ensures that the signer is unset and all subscriptions are cleared.
     pub(crate) async fn delete_all_data(&self) -> Result<()> {
         tracing::debug!(


### PR DESCRIPTION
Parallelize ensure_relays_connected, increase parallelization on batch subscription processing and reduce scope of signer lock.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - View current relay connection status for any relay.

- Improvements
  - Unified signer-aware subscription flows for account and group operations.
  - Centralized, parallel relay connection handling for faster, more reliable connections.
  - Group message subscriptions now use group relays as the source of truth.

- Bug Fixes
  - Fewer subscription failures and “no relay connection” errors via improved batching, aggregation, and error reporting.

- Removed
  - Deprecated signer-wrapped subscription helpers removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->