### PR TITLE
Track event created time on replaceable events

### DIFF
--- a/db_migrations/0014_add_event_created_at_columns.sql
+++ b/db_migrations/0014_add_event_created_at_columns.sql
@@ -1,0 +1,10 @@
+-- Add event_created_at columns to track original event timestamps
+-- This prevents stale events from overwriting newer data during sync operations
+
+-- Add event_created_at to users table for metadata events
+-- NULL indicates we don't have the original event timestamp (legacy data)
+ALTER TABLE users ADD COLUMN event_created_at INTEGER DEFAULT NULL;
+
+-- Add event_created_at to user_relays table for relay list events
+-- NULL indicates we don't have the original event timestamp (legacy data)
+ALTER TABLE user_relays ADD COLUMN event_created_at INTEGER DEFAULT NULL;

--- a/db_migrations/0014_add_event_created_at_columns.sql
+++ b/db_migrations/0014_add_event_created_at_columns.sql
@@ -8,3 +8,7 @@ ALTER TABLE users ADD COLUMN event_created_at INTEGER DEFAULT NULL;
 -- Add event_created_at to user_relays table for relay list events
 -- NULL indicates we don't have the original event timestamp (legacy data)
 ALTER TABLE user_relays ADD COLUMN event_created_at INTEGER DEFAULT NULL;
+
+-- Add event_created_at to account_follows table for contact list events
+-- NULL indicates we don't have the original event timestamp (legacy data)
+ALTER TABLE account_follows ADD COLUMN event_created_at INTEGER DEFAULT NULL;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,7 +71,10 @@ fn init_tracing(logs_dir: &std::path::Path) {
             .with_target(true);
 
         Registry::default()
-            .with(EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info,refinery_core=warn,refinery=warn")))
+            .with(
+                EnvFilter::try_from_default_env()
+                    .unwrap_or_else(|_| EnvFilter::new("info,refinery_core=warn,refinery=warn")),
+            )
             .with(stdout_layer)
             .with(file_layer)
             .init();

--- a/src/nostr_manager/publisher.rs
+++ b/src/nostr_manager/publisher.rs
@@ -308,7 +308,7 @@ mod publish_tests {
             .await
             .expect("Failed to fetch metadata from relays");
 
-        if let Some(fetched_metadata) = fetch_result {
+        if let Some((fetched_metadata, _timestamp)) = fetch_result {
             assert_eq!(fetched_metadata.name, metadata.name);
             assert_eq!(fetched_metadata.display_name, metadata.display_name);
             assert_eq!(fetched_metadata.about, metadata.about);

--- a/src/whitenoise/database/accounts.rs
+++ b/src/whitenoise/database/accounts.rs
@@ -197,7 +197,7 @@ impl Account {
     /// Returns a [`WhitenoiseError::AccountNotFound`] if the database query fails.
     pub(crate) async fn follows(&self, database: &Database) -> Result<Vec<User>, WhitenoiseError> {
         let user_rows = sqlx::query_as::<_, UserRow>(
-            "SELECT u.id, u.pubkey, u.metadata, u.created_at, u.updated_at
+            "SELECT u.id, u.pubkey, u.metadata, u.created_at, u.updated_at, u.event_created_at
              FROM account_follows af
              JOIN users u ON af.user_id = u.id
              WHERE af.account_id = ?",
@@ -215,6 +215,7 @@ impl Account {
                 metadata: row.metadata,
                 created_at: row.created_at,
                 updated_at: row.updated_at,
+                event_created_at: row.event_created_at,
             })
             .collect();
 
@@ -856,6 +857,7 @@ mod tests {
                 metadata: metadata.clone(),
                 created_at: test_timestamp,
                 updated_at: test_timestamp,
+                event_created_at: None,
             };
 
             // Save user first
@@ -980,6 +982,7 @@ mod tests {
             metadata: user_metadata.clone(),
             created_at: test_timestamp,
             updated_at: test_timestamp,
+            event_created_at: None,
         };
 
         // Save user
@@ -1057,6 +1060,7 @@ mod tests {
             metadata: user_metadata.clone(),
             created_at: test_timestamp,
             updated_at: test_timestamp,
+            event_created_at: None,
         };
 
         user.save(&whitenoise.database).await.unwrap();
@@ -1154,6 +1158,7 @@ mod tests {
                 metadata: user_metadata,
                 created_at: test_timestamp,
                 updated_at: test_timestamp,
+                event_created_at: None,
             };
 
             user.save(&whitenoise.database).await.unwrap();

--- a/src/whitenoise/event_processor/event_handlers/handle_contact_list.rs
+++ b/src/whitenoise/event_processor/event_handlers/handle_contact_list.rs
@@ -30,72 +30,50 @@ impl Whitenoise {
             account.pubkey.to_hex()
         );
 
-        let contacts_from_event = NostrManager::pubkeys_from_event(&event);
-        let contacts_set: std::collections::HashSet<nostr_sdk::PublicKey> =
-            contacts_from_event.iter().cloned().collect();
+        // Check if this event is newer than what we already have
+        let current_event_time = account.get_latest_follow_list_timestamp(&self.database).await?;
+        let event_timestamp = event.created_at.as_u64();
 
-        // Get current follows from database
-        let current_follows = account.follows(&self.database).await?;
-        let current_follows_set: std::collections::HashSet<nostr_sdk::PublicKey> =
-            current_follows.iter().map(|f| f.pubkey).collect();
-
-        // Find users to follow (in event but not in current follows)
-        let users_to_follow: Vec<nostr_sdk::PublicKey> = contacts_set
-            .difference(&current_follows_set)
-            .cloned()
-            .collect();
-
-        // Find users to unfollow (in current follows but not in event)
-        let users_to_unfollow: Vec<nostr_sdk::PublicKey> = current_follows_set
-            .difference(&contacts_set)
-            .cloned()
-            .collect();
-
-        tracing::debug!(
-            target: "whitenoise::handle_contact_list_internal",
-            "Processing contact list for account {}: {} to follow, {} to unfollow",
-            account.pubkey.to_hex(),
-            users_to_follow.len(),
-            users_to_unfollow.len()
-        );
-
-        // Check if we have changes to make before processing
-        let has_changes = !users_to_follow.is_empty() || !users_to_unfollow.is_empty();
-
-        if !has_changes {
-            tracing::debug!(
-                target: "whitenoise::handle_contact_list_internal",
-                "No changes to make to contact list for account {}",
-                account.pubkey.to_hex()
-            );
-            return Ok(());
-        }
-
-        for pubkey in &users_to_follow {
-            let (user, newly_created) =
-                crate::whitenoise::users::User::find_or_create_by_pubkey(pubkey, &self.database)
-                    .await?;
-
-            if newly_created {
-                self.background_fetch_user_data(&user).await?;
+        if let Some(current_time) = current_event_time {
+            if event_timestamp <= current_time {
+                tracing::debug!(
+                    target: "whitenoise::handle_contact_list",
+                    "Ignoring older contact list event (event: {}, current: {}) for account {}",
+                    event_timestamp,
+                    current_time,
+                    account.pubkey.to_hex()
+                );
+                return Ok(());
             }
-
-            account.follow_user(&user, &self.database).await?;
-        }
-
-        for pubkey in &users_to_unfollow {
-            let (user, created) =
-                crate::whitenoise::users::User::find_or_create_by_pubkey(pubkey, &self.database)
-                    .await?;
-            if created {
-                self.background_fetch_user_data(&user).await?;
-            }
-            account.unfollow_user(&user, &self.database).await?;
         }
 
         tracing::debug!(
             target: "whitenoise::handle_contact_list",
-            "Releasing concurrency guard for account {}",
+            "Processing contact list event (timestamp: {}) for account {}",
+            event_timestamp,
+            account.pubkey.to_hex()
+        );
+
+        let contacts_from_event = NostrManager::pubkeys_from_event(&event);
+
+        // Use the new bulk update method and get the list of newly created users
+        let newly_created_pubkeys = account.update_follows_from_event(contacts_from_event.clone(), event_timestamp, &self.database).await?;
+
+        // Store count for logging before consuming the vector
+        let newly_created_count = newly_created_pubkeys.len();
+
+        // Background fetch user data for newly created users
+        for pubkey in newly_created_pubkeys {
+            if let Ok((user, _)) = crate::whitenoise::users::User::find_or_create_by_pubkey(&pubkey, &self.database).await {
+                self.background_fetch_user_data(&user).await?;
+            }
+        }
+
+        tracing::debug!(
+            target: "whitenoise::handle_contact_list",
+            "Successfully processed contact list with {} contacts ({} newly created) for account {}",
+            contacts_from_event.len(),
+            newly_created_count,
             account.pubkey.to_hex()
         );
 

--- a/src/whitenoise/event_processor/event_handlers/handle_metadata.rs
+++ b/src/whitenoise/event_processor/event_handlers/handle_metadata.rs
@@ -1,3 +1,4 @@
+use chrono::DateTime;
 use nostr_sdk::prelude::*;
 
 use crate::whitenoise::{
@@ -15,8 +16,27 @@ impl Whitenoise {
                 // Only update metadata if this event is newer than our current data
                 // For newly created users, always accept the metadata
                 let event_timestamp = event.created_at.as_u64() as i64;
-                if newly_created || event_timestamp > user.updated_at.timestamp() {
+                let should_update = newly_created || match user.event_created_at {
+                    None => {
+                        // No stored event timestamp (legacy data), accept the new event
+                        tracing::debug!(
+                            target: "whitenoise::event_processor::handle_metadata",
+                            "No stored event timestamp for user {}, accepting new event",
+                            event.pubkey
+                        );
+                        true
+                    }
+                    Some(stored_timestamp) => {
+                        // Compare with the actual stored event timestamp
+                        event_timestamp > stored_timestamp.timestamp()
+                    }
+                };
+
+                if should_update {
                     user.metadata = metadata;
+                    // Update the event timestamp to the new event's timestamp
+                    user.event_created_at = Some(DateTime::from_timestamp(event_timestamp, 0)
+                        .unwrap_or_else(chrono::Utc::now));
                     let _ = user.save(&self.database).await?;
                     tracing::debug!(
                         target: "whitenoise::event_processor::handle_metadata",
@@ -25,12 +45,15 @@ impl Whitenoise {
                         event_timestamp
                     );
                 } else {
+                    let stored_timestamp = user.event_created_at
+                        .map(|dt| dt.timestamp())
+                        .unwrap_or(0);
                     tracing::debug!(
                         target: "whitenoise::event_processor::handle_metadata",
-                        "Ignoring stale metadata event for user {} (event: {}, current: {})",
+                        "Ignoring stale metadata event for user {} (event: {}, stored: {})",
                         event.pubkey,
                         event_timestamp,
-                        user.updated_at.timestamp()
+                        stored_timestamp
                     );
                 }
                 Ok(())

--- a/src/whitenoise/event_processor/event_handlers/handle_relay_list.rs
+++ b/src/whitenoise/event_processor/event_handlers/handle_relay_list.rs
@@ -1,3 +1,4 @@
+use chrono::{DateTime, Utc};
 use nostr_sdk::prelude::*;
 
 use crate::{
@@ -12,7 +13,11 @@ impl Whitenoise {
 
         let relay_type = event.kind.into();
         let relay_urls = NostrManager::relay_urls_from_event(event.clone());
-        let relays_changed = user.sync_relay_urls(self, relay_type, &relay_urls).await?;
+        let event_created_at = Some(DateTime::from_timestamp(event.created_at.as_u64() as i64, 0)
+            .unwrap_or_else(Utc::now));
+        let relays_changed = user
+            .sync_relay_urls(self, relay_type, &relay_urls, event_created_at)
+            .await?;
 
         if relays_changed {
             self.handle_subscriptions_refresh(&user, &event).await;


### PR DESCRIPTION
This PR adds tracking the `created_at` time of the replaceable event into a field on `User`, `UserRelay`, and `UserFollow` rows in the database to be sure that we don't overwrite our local data with stale or outdated data. 