### PR TITLE
Edge case fix for old data migration

### DIFF
--- a/db_migrations/0006_data_migration.sql
+++ b/db_migrations/0006_data_migration.sql
@@ -15,6 +15,15 @@ SELECT
 FROM contacts
 WHERE NOT EXISTS (SELECT 1 FROM users WHERE users.pubkey = contacts.pubkey);
 
+-- Step 1.5: FIXES EDGE CASE - Create users for accounts that don't have corresponding contacts
+-- This ensures every account will have a user record before Step 6
+INSERT INTO users (pubkey, metadata)
+SELECT
+    pubkey,
+    NULL as metadata  -- No metadata available for accounts without contacts
+FROM accounts
+WHERE NOT EXISTS (SELECT 1 FROM users WHERE users.pubkey = accounts.pubkey);
+
 -- Step 2: Extract and insert unique relay URLs from contacts
 -- Extract from nip65_relays
 INSERT OR IGNORE INTO relays (url)
@@ -164,6 +173,7 @@ WHERE json_valid(a.key_package_relays)
   AND relay_value.value != '';
 
 -- Step 6: Migrate accounts to accounts_new table
+-- Now this INNER JOIN is safe because we ensured every account has a user record in Step 1.5
 INSERT INTO accounts_new (pubkey, user_id, settings, last_synced_at)
 SELECT
     a.pubkey,

--- a/db_migrations/0006_data_migration.sql
+++ b/db_migrations/0006_data_migration.sql
@@ -26,15 +26,6 @@ FROM accounts
 WHERE pubkey IS NOT NULL
   AND TRIM(pubkey) != '';
 
--- Step 1.5: FIXES EDGE CASE - Create users for accounts that don't have corresponding contacts
--- This ensures every account will have a user record before Step 6
-INSERT INTO users (pubkey, metadata)
-SELECT
-    pubkey,
-    NULL as metadata  -- No metadata available for accounts without contacts
-FROM accounts
-WHERE NOT EXISTS (SELECT 1 FROM users WHERE users.pubkey = accounts.pubkey);
-
 -- Step 2: Extract and insert unique relay URLs from contacts
 -- Extract from nip65_relays
 INSERT OR IGNORE INTO relays (url)

--- a/db_migrations/0006_data_migration.sql
+++ b/db_migrations/0006_data_migration.sql
@@ -3,8 +3,8 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_user_relays_unique
 ON user_relays (user_id, relay_id, relay_type);
 
 -- Step 1: Migrate contacts to users table
-INSERT INTO users (pubkey, metadata)
-SELECT
+INSERT OR IGNORE INTO users (pubkey, metadata)
+SELECT DISTINCT
     pubkey,
     CASE
         WHEN json_valid(NULLIF(TRIM(metadata), ''))
@@ -13,7 +13,18 @@ SELECT
         ELSE NULL
     END AS metadata
 FROM contacts
-WHERE NOT EXISTS (SELECT 1 FROM users WHERE users.pubkey = contacts.pubkey);
+WHERE pubkey IS NOT NULL
+  AND TRIM(pubkey) != '';
+
+-- Step 1.5: CRITICAL FIX - Create users for accounts that don't have corresponding contacts
+-- This ensures every account will have a user record before Step 6
+INSERT OR IGNORE INTO users (pubkey, metadata)
+SELECT DISTINCT
+    pubkey,
+    NULL as metadata  -- No metadata available for accounts without contacts
+FROM accounts
+WHERE pubkey IS NOT NULL
+  AND TRIM(pubkey) != '';
 
 -- Step 1.5: FIXES EDGE CASE - Create users for accounts that don't have corresponding contacts
 -- This ensures every account will have a user record before Step 6


### PR DESCRIPTION
This changes an older migration so it's only possible to merge this before our next release. 

In the case that an Account didn't have a corresponding contact record in the system before the migration, that account would not get created in the new table because of a pesky `JOIN` clause in the data migration. This creates a user record before creating the new account to fix this.

Potentially part of the solution to: https://github.com/parres-hq/whitenoise_flutter/issues/557

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Backfills missing user records for accounts and prevents duplicate relay and user-relay entries to improve data consistency.

* **Chores**
  * Makes migration idempotent across relay and relationship inserts and validates derived user metadata to avoid invalid values.

* **Documentation**
  * Adds a note clarifying why a later join is safe due to the earlier backfill and the added safety guard.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->