### PR TITLE
feat(integration_tests): add retry helper and use it to reduce flakiness

### DIFF
--- a/src/integration_tests/core/mod.rs
+++ b/src/integration_tests/core/mod.rs
@@ -1,9 +1,11 @@
 pub mod context;
+pub mod retry;
 pub mod scenario_result;
 pub mod test_clients;
 pub mod traits;
 
 pub use context::*;
+pub use retry::*;
 pub use scenario_result::*;
 pub use test_clients::*;
 pub use traits::*;

--- a/src/integration_tests/core/retry.rs
+++ b/src/integration_tests/core/retry.rs
@@ -1,0 +1,102 @@
+use crate::WhitenoiseError;
+use std::future::Future;
+use std::time::Duration;
+
+#[derive(Debug, Clone)]
+pub struct RetryConfig {
+    pub max_retries: usize,
+    pub delay: Duration,
+}
+
+impl Default for RetryConfig {
+    fn default() -> Self {
+        Self {
+            max_retries: 10,
+            delay: Duration::from_millis(100),
+        }
+    }
+}
+
+impl RetryConfig {
+    /// Create custom retry configuration
+    pub fn new(max_retries: usize, delay: Duration) -> Self {
+        Self { max_retries, delay }
+    }
+}
+
+/// Retry an async operation until it succeeds or max retries is reached
+pub async fn retry_until<F, Fut, T>(
+    config: RetryConfig,
+    operation: F,
+    description: &str,
+) -> Result<T, WhitenoiseError>
+where
+    F: Fn() -> Fut,
+    Fut: Future<Output = Result<T, WhitenoiseError>>,
+{
+    let mut retry_count = 0;
+
+    loop {
+        match operation().await {
+            Ok(result) => {
+                if retry_count > 0 {
+                    tracing::info!("✓ {} succeeded after {} retries", description, retry_count);
+                }
+                return Ok(result);
+            }
+            Err(e) => {
+                retry_count += 1;
+
+                if retry_count >= config.max_retries {
+                    tracing::error!(
+                        "✗ {} failed after {} retries: {}",
+                        description,
+                        retry_count,
+                        e
+                    );
+                    return Err(WhitenoiseError::Other(anyhow::anyhow!(
+                        "Operation '{}' failed after {} retries: {}",
+                        description,
+                        retry_count,
+                        e
+                    )));
+                }
+
+                let delay = config.delay;
+                tracing::debug!(
+                    "Retry {}/{}: {} failed, waiting {:?} before retry",
+                    retry_count,
+                    config.max_retries,
+                    description,
+                    delay
+                );
+
+                tokio::time::sleep(delay).await;
+            }
+        }
+    }
+}
+
+/// Retry with default configuration (10 retries, 100ms delay)
+pub async fn retry_default<F, Fut, T>(operation: F, description: &str) -> Result<T, WhitenoiseError>
+where
+    F: Fn() -> Fut,
+    Fut: Future<Output = Result<T, WhitenoiseError>>,
+{
+    retry_until(RetryConfig::default(), operation, description).await
+}
+
+/// Retry with custom configuration
+pub async fn retry<F, Fut, T>(
+    max_retries: usize,
+    delay: Duration,
+    operation: F,
+    description: &str,
+) -> Result<T, WhitenoiseError>
+where
+    F: Fn() -> Fut,
+    Fut: Future<Output = Result<T, WhitenoiseError>>,
+{
+    let config = RetryConfig::new(max_retries, delay);
+    retry_until(config, operation, description).await
+}

--- a/src/integration_tests/core/test_clients.rs
+++ b/src/integration_tests/core/test_clients.rs
@@ -1,6 +1,5 @@
 use crate::WhitenoiseError;
 use nostr_sdk::prelude::*;
-use std::time::Duration;
 
 pub async fn create_test_client(relays: &[&str], keys: Keys) -> Result<Client, WhitenoiseError> {
     let client = Client::default();
@@ -10,7 +9,6 @@ pub async fn create_test_client(relays: &[&str], keys: Keys) -> Result<Client, W
 
     client.connect().await;
     client.set_signer(keys).await;
-    tokio::time::sleep(Duration::from_millis(300)).await;
 
     Ok(client)
 }

--- a/src/integration_tests/scenarios/advanced_messaging.rs
+++ b/src/integration_tests/scenarios/advanced_messaging.rs
@@ -81,9 +81,6 @@ impl Scenario for AdvancedMessagingScenario {
             .execute(&mut self.context)
             .await?;
 
-        // Wait a bit more after successful message
-        tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
-
         // Now send reactions to different messages
         SendMessageTestCase::basic()
             .with_sender("adv_msg_reactor")

--- a/src/integration_tests/test_cases/account_management/login.rs
+++ b/src/integration_tests/test_cases/account_management/login.rs
@@ -57,7 +57,6 @@ impl TestCase for LoginTestCase {
         publish_relay_lists(&test_client, relay_urls).await?;
 
         test_client.disconnect().await;
-        tokio::time::sleep(tokio::time::Duration::from_millis(300)).await;
 
         // Login with the keys
         let account = context

--- a/src/integration_tests/test_cases/user_discovery/find_or_create_user.rs
+++ b/src/integration_tests/test_cases/user_discovery/find_or_create_user.rs
@@ -125,18 +125,23 @@ impl TestCase for FindOrCreateUserTestCase {
 
         tracing::info!("✓ User can be found by pubkey after creation");
 
-        // If we expect metadata, poll until it arrives (for CI timing issues)
+        // If we expect metadata, wait until it arrives (for CI timing issues)
         if self.should_have_metadata && user.metadata == nostr_sdk::Metadata::default() {
-            tracing::info!("Metadata not yet available, polling for updates...");
-            for attempt in 1..=10 {
-                tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
-                user = context.whitenoise.find_user_by_pubkey(&test_pubkey).await?;
-                if user.metadata != nostr_sdk::Metadata::default() {
-                    tracing::info!("✓ Metadata received after {} attempts", attempt);
-                    break;
-                }
-                tracing::debug!("Attempt {}: Still waiting for metadata...", attempt);
-            }
+            tracing::info!("Metadata not yet available, waiting for updates...");
+            user = retry_default(
+                || async {
+                    let updated_user = context.whitenoise.find_user_by_pubkey(&test_pubkey).await?;
+                    if updated_user.metadata != nostr_sdk::Metadata::default() {
+                        Ok(updated_user)
+                    } else {
+                        Err(WhitenoiseError::Other(anyhow::anyhow!(
+                            "Metadata not yet available"
+                        )))
+                    }
+                },
+                &format!("wait for metadata for user {}", &test_pubkey.to_hex()[..8]),
+            )
+            .await?;
         }
 
         if self.should_have_metadata {


### PR DESCRIPTION
Fixes https://github.com/parres-hq/whitenoise/issues/325

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Introduced a reusable async retry utility to handle eventual consistency across operations.

- Tests
  - Replaced fixed delays with adaptive retries in messaging, follow/unfollow, group membership, account login, and user discovery scenarios.
  - Improved diagnostics and logging for easier troubleshooting on failure.
  - Reduced test flakiness and potential runtime by eliminating arbitrary waits.

- Refactor
  - Centralized retry logic and removed scattered manual polling/sleep patterns to streamline test flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->