### PR TITLE
Feat/subscription monitoring

### DIFF
--- a/src/nostr_manager/mod.rs
+++ b/src/nostr_manager/mod.rs
@@ -412,8 +412,7 @@ impl NostrManager {
     }
 
     /// Counts active subscriptions for a specific account by checking subscription IDs.
-    /// Returns the number of subscriptions that start with the account's hashed pubkey prefix.
-    #[allow(dead_code)]
+    /// Returns the number of subscriptions that contain the account's hashed pubkey.
     pub(crate) async fn count_subscriptions_for_account(&self, pubkey: &PublicKey) -> usize {
         let hash = self.create_pubkey_hash(pubkey);
         let prefix = format!("{}_", hash);
@@ -426,7 +425,6 @@ impl NostrManager {
     }
 
     /// Counts active global subscriptions by checking for subscription IDs that start with "global_users_".
-    #[allow(dead_code)]
     pub(crate) async fn count_global_subscriptions(&self) -> usize {
         self.client
             .subscriptions()
@@ -438,7 +436,6 @@ impl NostrManager {
 
     /// Checks if at least one relay in the provided list is connected or connecting.
     /// Returns true if any relay is in Connected or Connecting state.
-    #[allow(dead_code)]
     pub(crate) async fn has_any_relay_connected(&self, relay_urls: &[RelayUrl]) -> bool {
         for relay_url in relay_urls {
             match self.get_relay_status(relay_url).await {

--- a/src/nostr_manager/subscriptions.rs
+++ b/src/nostr_manager/subscriptions.rs
@@ -16,7 +16,7 @@ use crate::nostr_manager::{
 impl NostrManager {
     /// Create a short hash from a pubkey for use in subscription IDs
     /// Uses first 12 characters of SHA256 hash for privacy and collision resistance, salted per session
-    fn create_pubkey_hash(&self, pubkey: &PublicKey) -> String {
+    pub(crate) fn create_pubkey_hash(&self, pubkey: &PublicKey) -> String {
         let mut hasher = Sha256::new();
         hasher.update(self.session_salt());
         hasher.update(pubkey.to_bytes());

--- a/src/whitenoise/relays.rs
+++ b/src/whitenoise/relays.rs
@@ -108,16 +108,21 @@ impl Whitenoise {
         Relay::find_or_create_by_url(url, &self.database).await
     }
 
-    /// Fetches the status of relays associated with a user's public key.
+    /// Get connection status for all of an account's relays.
     ///
     /// This method returns a list of relay statuses for relays that are configured
-    /// for the given account. It gets the relay URLs from the user's relay lists
-    /// and then returns the current connection status from the Nostr client.
+    /// for the given account. It retrieves relay URLs from the account's relay lists
+    /// (NIP-65, inbox, and key package relays) and returns the current connection
+    /// status from the Nostr client.
     ///
     /// # Arguments
     ///
-    /// * `pubkey` - The `PublicKey` of the user whose relay statuses should be fetched.
-    pub async fn fetch_relay_status(
+    /// * `account` - The account whose relay statuses should be retrieved.
+    ///
+    /// # Returns
+    ///
+    /// Returns a vector of tuples containing relay URLs and their connection status.
+    pub async fn get_account_relay_statuses(
         &self,
         account: &Account,
     ) -> Result<Vec<(RelayUrl, RelayStatus)>> {


### PR DESCRIPTION
Adds `ensure_all_subscriptions` to be called from a background periodic task in an attempt to keep the connections/subscriptions alive and functioning.

It also fixes docstrings/comment and changes renames the `fetch_relay_status` method to `get_account_relay_statuses` to be more explicit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Holistic subscription management: ensure per-account, global, and all-subscriptions refresh paths with operational checks.
  * Account-focused relay status retrieval and connectivity detection.
  * Utilities to count subscriptions and detect any connected relays for monitoring/UI.

* **Tests**
  * Expanded test suite covering subscription counts, global checks, relay connectivity scenarios, group relay extraction, and refresh/idempotency behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->